### PR TITLE
캔버스에 화면 공유 그리기

### DIFF
--- a/components/debateroom/Buttons.tsx
+++ b/components/debateroom/Buttons.tsx
@@ -4,8 +4,6 @@ import { toggleAudioOnOff, toggleVideoOnOff } from "./utils/toggleOnOff";
 import { IDebateroomProps } from "./types";
 
 export default function Buttons({
-  debateId,
-  socket,
   peer,
   streamRef,
   videoRef,
@@ -16,8 +14,6 @@ export default function Buttons({
   setIsScreenOn,
 }: Pick<
   IDebateroomProps,
-  | "debateId"
-  | "socket"
   | "peer"
   | "streamRef"
   | "videoRef"
@@ -38,28 +34,13 @@ export default function Buttons({
       </button>
       <button
         onClick={() =>
-          toggleVideoOnOff(
-            debateId,
-            socket,
-            streamRef,
-            isVideoOn ? false : true,
-            setIsVideoOn,
-          )
+          toggleVideoOnOff(streamRef, isVideoOn ? false : true, setIsVideoOn)
         }
       >
         {isVideoOn ? "VideoOff" : "VideoOn"}
       </button>
       <button
-        onClick={() =>
-          screenShare(
-            debateId,
-            socket,
-            peer,
-            streamRef,
-            videoRef,
-            setIsScreenOn,
-          )
-        }
+        onClick={() => screenShare(peer, streamRef, videoRef, setIsScreenOn)}
       >
         ScreenShare
       </button>

--- a/components/debateroom/Canvas.tsx
+++ b/components/debateroom/Canvas.tsx
@@ -17,7 +17,6 @@ export default function Canvas({
   isPeerScreenOn,
   dummy,
   isPros,
-  isStart,
 }: Pick<
   IDebateroomProps,
   | "peer"
@@ -29,7 +28,6 @@ export default function Canvas({
   | "isPeerVideoOn"
   | "isScreenOn"
   | "isPeerScreenOn"
-  | "isStart"
   | "dummy"
   | "isPros"
 >) {
@@ -46,7 +44,6 @@ export default function Canvas({
         isPeerVideoOn,
         isScreenOn,
         isPeerScreenOn,
-        isStart,
         dummy,
         isPros,
       ),

--- a/components/debateroom/Canvas.tsx
+++ b/components/debateroom/Canvas.tsx
@@ -29,9 +29,9 @@ export default function Canvas({
   | "isPeerVideoOn"
   | "isScreenOn"
   | "isPeerScreenOn"
+  | "isStart"
   | "dummy"
   | "isPros"
-  | "isStart"
 >) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const blobsRef = useRef<Blob[]>([]);
@@ -46,9 +46,9 @@ export default function Canvas({
         isPeerVideoOn,
         isScreenOn,
         isPeerScreenOn,
+        isStart,
         dummy,
         isPros,
-        isStart,
       ),
     1000 / 30,
   );
@@ -82,6 +82,7 @@ export default function Canvas({
   }, [
     drawStart,
     drawStop,
+    peer,
     isVideoOn,
     isPeerVideoOn,
     isScreenOn,

--- a/components/debateroom/Room.tsx
+++ b/components/debateroom/Room.tsx
@@ -33,7 +33,7 @@ export default function Room({ debateId, socket }: IRoomProps) {
     topic: "Is Alien Exist?",
     prosName: "이찬성",
     consName: "반대중",
-    isProsTurn: true,
+    prosTurn: "false",
   });
   const [isPros, setIsPros] = useState(true);
 
@@ -107,9 +107,9 @@ export default function Room({ debateId, socket }: IRoomProps) {
   useEffect(() => {
     if (peer) {
       socket?.emit("peerVideo", { debateId, isVideoOn });
-      socket?.emit("peerScreen", { debateId, isPeerScreenOn });
+      socket?.emit("peerScreen", { debateId, isScreenOn });
     }
-  }, [socket, peer, debateId, isVideoOn, isPeerScreenOn]);
+  }, [debateId, socket, peer, isVideoOn, isScreenOn]);
 
   return (
     <div>
@@ -141,7 +141,6 @@ export default function Room({ debateId, socket }: IRoomProps) {
         isPeerVideoOn={isPeerVideoOn}
         isScreenOn={isScreenOn}
         isPeerScreenOn={isPeerScreenOn}
-        isStart={isStart}
         dummy={dummy}
         isPros={isPros}
       />

--- a/components/debateroom/Room.tsx
+++ b/components/debateroom/Room.tsx
@@ -15,6 +15,8 @@ interface IRoomProps {
 
 export default function Room({ debateId, socket }: IRoomProps) {
   const [peer, setPeer] = useState<Peer.Instance>();
+  const recorderRef = useRef<MediaRecorder>();
+  const downRef = useRef<HTMLAnchorElement>(null);
   const streamRef = useRef<MediaStream>();
   const peerStreamRef = useRef<MediaStream>();
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -24,8 +26,7 @@ export default function Room({ debateId, socket }: IRoomProps) {
   const [isPeerVideoOn, setIsPeerVideoOn] = useState<boolean>(true);
   const [isScreenOn, setIsScreenOn] = useState<boolean>(false);
   const [isPeerScreenOn, setIsPeerScreenOn] = useState<boolean>(false);
-  const recorderRef = useRef<MediaRecorder>();
-  const downRef = useRef<HTMLAnchorElement>(null);
+  const [isStart, setIsStart] = useState(false);
 
   //! 임시 변수
   const [dummy] = useState<IDummy>({
@@ -35,7 +36,19 @@ export default function Room({ debateId, socket }: IRoomProps) {
     isProsTurn: true,
   });
   const [isPros, setIsPros] = useState(true);
-  const [isStart, setIsStart] = useState(false);
+
+  //! 임시 함수
+  function downloadRecord() {
+    downRef.current?.click();
+  }
+
+  function startRecord() {
+    recorderRef.current?.start(1000 / 30);
+  }
+
+  function stopRecord() {
+    recorderRef.current?.stop();
+  }
 
   useEffect(() => {
     if (debateId && socket) {
@@ -91,18 +104,12 @@ export default function Room({ debateId, socket }: IRoomProps) {
     }
   }, [debateId, socket]);
 
-  //! 임시 함수
-  function downloadRecord() {
-    downRef.current?.click();
-  }
-
-  function startRecord() {
-    recorderRef.current?.start(1000 / 30);
-  }
-
-  function stopRecord() {
-    recorderRef.current?.stop();
-  }
+  useEffect(() => {
+    if (peer) {
+      socket?.emit("peerVideo", { debateId, isVideoOn });
+      socket?.emit("peerScreen", { debateId, isPeerScreenOn });
+    }
+  }, [socket, peer, debateId, isVideoOn, isPeerScreenOn]);
 
   return (
     <div>
@@ -134,13 +141,11 @@ export default function Room({ debateId, socket }: IRoomProps) {
         isPeerVideoOn={isPeerVideoOn}
         isScreenOn={isScreenOn}
         isPeerScreenOn={isPeerScreenOn}
+        isStart={isStart}
         dummy={dummy}
         isPros={isPros}
-        isStart={isStart}
       />
       <Buttons
-        debateId={debateId}
-        socket={socket}
         peer={peer}
         streamRef={streamRef}
         videoRef={videoRef}

--- a/components/debateroom/types.ts
+++ b/components/debateroom/types.ts
@@ -6,6 +6,8 @@ export interface IDebateroomProps {
   debateId: string | string[] | undefined;
   socket: Socket | undefined;
   peer: Peer.Instance | undefined;
+  recorderRef: MutableRefObject<MediaRecorder | undefined>;
+  downRef: MutableRefObject<HTMLAnchorElement | null>;
   setPeer: (peer: Peer.Instance | undefined) => void;
   streamRef: MutableRefObject<MediaStream | undefined>;
   videoRef: MutableRefObject<HTMLVideoElement | null>;
@@ -20,11 +22,10 @@ export interface IDebateroomProps {
   setIsScreenOn: (isScreenON: boolean) => void;
   isPeerScreenOn: boolean;
   setIsPeerScreenOn: (isScreenON: boolean) => void;
-  recorderRef: MutableRefObject<MediaRecorder | undefined>;
-  downRef: MutableRefObject<HTMLAnchorElement | null>;
+  isStart: boolean;
+  //! 임시 타입
   dummy: IDummy;
   isPros: boolean;
-  isStart: boolean;
 }
 
 //! 임시 타입

--- a/components/debateroom/types.ts
+++ b/components/debateroom/types.ts
@@ -33,5 +33,5 @@ export interface IDummy {
   topic: string;
   prosName: string;
   consName: string;
-  isProsTurn: boolean;
+  prosTurn: string;
 }

--- a/components/debateroom/utils/draw.ts
+++ b/components/debateroom/utils/draw.ts
@@ -3,6 +3,20 @@ import Peer from "simple-peer";
 
 import { IDummy } from "./../types";
 
+interface IColor {
+  bg: string;
+  black: string;
+  pros: string;
+  cons: string;
+}
+
+const color: IColor = {
+  bg: "#F8FBFD",
+  black: "#292929",
+  pros: "#ff9425",
+  cons: "#6667ab",
+};
+
 const drawSquare = (
   canvasRef: MutableRefObject<HTMLCanvasElement | null>,
   color: string,
@@ -35,38 +49,70 @@ const drawText = (
   }
 };
 
+const resize = (screen: HTMLVideoElement) => {
+  let w = 0;
+  let h = 0;
+
+  if (screen.videoWidth >= screen.videoHeight) {
+    w = 1280;
+    h = (1280 * screen.videoHeight) / screen.videoWidth;
+    if (h > 720) {
+      w = (1280 * 720) / h;
+      h = 720;
+    }
+  } else {
+    w = (720 * screen.videoWidth) / screen.videoHeight;
+    h = 720;
+  }
+
+  return [w, h];
+};
+
 export const draw = (
   canvasRef: MutableRefObject<HTMLCanvasElement | null>,
   peer: Peer.Instance | undefined,
-  myVideoRef: MutableRefObject<HTMLVideoElement | null>,
+  videoRef: MutableRefObject<HTMLVideoElement | null>,
   peerVideoRef: MutableRefObject<HTMLVideoElement | null>,
   isVideoOn: boolean,
   isPeerVideoOn: boolean,
   isScreenOn: boolean,
   isPeerScreenOn: boolean,
-  isStart: boolean,
   dummy: IDummy,
   isPros: boolean,
 ) => {
   // Common Bg
-  drawSquare(canvasRef, "#F8FBFD", 0, 80, 1280, 640);
+  drawSquare(canvasRef, color.bg, 0, 80, 1280, 640);
 
-  if (isScreenOn && isPros === dummy.isProsTurn && isStart) {
-    //! 내 화면 크게
-  } else if (isPeerScreenOn && isPros === dummy.isProsTurn && isStart) {
-    //! 상대 화면 크게
+  // My screen share
+  if (isScreenOn && String(isPros) === dummy.prosTurn) {
+    if (videoRef.current) {
+      drawSquare(canvasRef, color.black, 0, 80, 1280, 640);
+      const [w, h] = resize(videoRef.current);
+      canvasRef.current
+        ?.getContext("2d")
+        ?.drawImage(videoRef.current, 640 - w / 2, 440 - h / 2, w, h);
+    }
+    // Peer screen share
+  } else if (isPeerScreenOn && String(!isPros) === dummy.prosTurn) {
+    if (peerVideoRef.current) {
+      drawSquare(canvasRef, color.black, 0, 80, 1280, 640);
+      const [w, h] = resize(peerVideoRef.current);
+      canvasRef.current
+        ?.getContext("2d")
+        ?.drawImage(peerVideoRef.current, 640 - w / 2, 440 - h / 2, w, h);
+    }
   } else {
     // VS
-    drawText(canvasRef, "#292929", "bold 48px san-serif", "VS", 640, 420);
+    drawText(canvasRef, color.black, "bold 48px san-serif", "VS", 640, 420);
 
     // prosOuterBg
-    drawSquare(canvasRef, "#ff9425", 40, 110, 520, 520);
+    drawSquare(canvasRef, color.pros, 40, 110, 520, 520);
     // prosInnerBg
-    drawSquare(canvasRef, "#292929", 50, 120, 500, 500);
+    drawSquare(canvasRef, color.black, 50, 120, 500, 500);
     // prosName
     drawText(
       canvasRef,
-      "#ff9425",
+      color.pros,
       "bold 32px san-serif",
       `${dummy.prosName}`,
       300,
@@ -75,7 +121,7 @@ export const draw = (
     // prosText
     drawText(
       canvasRef,
-      "#F8FBFD",
+      color.bg,
       "bold 32px san-serif",
       peer ? "Camera Off" : isPros ? "Camera Off" : "Not connected",
       300,
@@ -83,13 +129,13 @@ export const draw = (
     );
 
     // consOuterBg
-    drawSquare(canvasRef, "#6667ab", 720, 110, 520, 520);
+    drawSquare(canvasRef, color.cons, 720, 110, 520, 520);
     // consInnerBg
-    drawSquare(canvasRef, "#292929", 730, 120, 500, 500);
+    drawSquare(canvasRef, color.black, 730, 120, 500, 500);
     // consName
     drawText(
       canvasRef,
-      "#6667ab",
+      color.cons,
       "bold 32px san-serif",
       `${dummy.consName}`,
       980,
@@ -98,7 +144,7 @@ export const draw = (
     // consText
     drawText(
       canvasRef,
-      "#F8FBFD",
+      color.bg,
       "bold 32px san-serif",
       peer ? "Camera Off" : !isPros ? "Camera Off" : "Not connected",
       980,
@@ -106,9 +152,9 @@ export const draw = (
     );
 
     // Video
-    if (myVideoRef.current && peerVideoRef.current) {
-      const prosVideo = isPros ? myVideoRef.current : peerVideoRef.current;
-      const consVideo = isPros ? peerVideoRef.current : myVideoRef.current;
+    if (videoRef.current && peerVideoRef.current) {
+      const prosVideo = isPros ? videoRef.current : peerVideoRef.current;
+      const consVideo = isPros ? peerVideoRef.current : videoRef.current;
       const IsProsVideoOn = isPros ? isVideoOn : isPeerVideoOn;
       const IsConsVideoOn = isPros ? isPeerVideoOn : isVideoOn;
 

--- a/components/debateroom/utils/draw.ts
+++ b/components/debateroom/utils/draw.ts
@@ -44,9 +44,9 @@ export const draw = (
   isPeerVideoOn: boolean,
   isScreenOn: boolean,
   isPeerScreenOn: boolean,
+  isStart: boolean,
   dummy: IDummy,
   isPros: boolean,
-  isStart: boolean,
 ) => {
   // Common Bg
   drawSquare(canvasRef, "#F8FBFD", 0, 80, 1280, 640);
@@ -56,10 +56,14 @@ export const draw = (
   } else if (isPeerScreenOn && isPros === dummy.isProsTurn && isStart) {
     //! 상대 화면 크게
   } else {
-    drawText(canvasRef, "#292929", "bold 48px san-serif", "VS", 640, 420); // V
+    // VS
+    drawText(canvasRef, "#292929", "bold 48px san-serif", "VS", 640, 420);
 
-    drawSquare(canvasRef, "#ff9425", 40, 110, 520, 520); // prosOuterBg
-    drawSquare(canvasRef, "#292929", 50, 120, 500, 500); // prosInnerBg
+    // prosOuterBg
+    drawSquare(canvasRef, "#ff9425", 40, 110, 520, 520);
+    // prosInnerBg
+    drawSquare(canvasRef, "#292929", 50, 120, 500, 500);
+    // prosName
     drawText(
       canvasRef,
       "#ff9425",
@@ -67,18 +71,22 @@ export const draw = (
       `${dummy.prosName}`,
       300,
       680,
-    ); // prosName
+    );
+    // prosText
     drawText(
       canvasRef,
       "#F8FBFD",
       "bold 32px san-serif",
-      peer ? "Camera Off" : "Not connected",
+      peer ? "Camera Off" : isPros ? "Camera Off" : "Not connected",
       300,
       380,
-    ); // prosText
+    );
 
-    drawSquare(canvasRef, "#6667ab", 720, 110, 520, 520); // consOuterBg
-    drawSquare(canvasRef, "#292929", 730, 120, 500, 500); // consInnerBg
+    // consOuterBg
+    drawSquare(canvasRef, "#6667ab", 720, 110, 520, 520);
+    // consInnerBg
+    drawSquare(canvasRef, "#292929", 730, 120, 500, 500);
+    // consName
     drawText(
       canvasRef,
       "#6667ab",
@@ -86,15 +94,16 @@ export const draw = (
       `${dummy.consName}`,
       980,
       680,
-    ); // consName
+    );
+    // consText
     drawText(
       canvasRef,
       "#F8FBFD",
       "bold 32px san-serif",
-      peer ? "Camera Off" : "Not connected",
+      peer ? "Camera Off" : !isPros ? "Camera Off" : "Not connected",
       980,
       380,
-    ); // consText
+    );
 
     // Video
     if (myVideoRef.current && peerVideoRef.current) {

--- a/components/debateroom/utils/screenShare.ts
+++ b/components/debateroom/utils/screenShare.ts
@@ -1,10 +1,7 @@
 import { MutableRefObject } from "react";
-import { Socket } from "socket.io-client";
 import Peer from "simple-peer";
 
 export const screenShare = async (
-  debateId: string | string[] | undefined,
-  socket: Socket | undefined,
   peer: Peer.Instance | undefined,
   streamRef: MutableRefObject<MediaStream | undefined>,
   videoRef: MutableRefObject<HTMLVideoElement | null>,
@@ -24,7 +21,6 @@ export const screenShare = async (
       );
       videoRef.current.srcObject = screenStream;
       setIsScreenOn(true);
-      socket?.emit("peerScreen", { debateId, isPeerScreenOn: true });
     }
 
     screenStream.getTracks()[0].onended = () => {
@@ -36,7 +32,6 @@ export const screenShare = async (
         );
         videoRef.current.srcObject = streamRef.current;
         setIsScreenOn(false);
-        socket?.emit("peerScreen", { debateId, isPeerScreenOn: false });
       }
     };
   } catch (err) {

--- a/components/debateroom/utils/toggleOnOff.ts
+++ b/components/debateroom/utils/toggleOnOff.ts
@@ -1,5 +1,4 @@
 import { MutableRefObject } from "react";
-import { Socket } from "socket.io-client";
 
 export const toggleAudioOnOff = (
   streamRef: MutableRefObject<MediaStream | undefined>,
@@ -13,8 +12,6 @@ export const toggleAudioOnOff = (
 };
 
 export const toggleVideoOnOff = (
-  debateId: string | string[] | undefined,
-  socket: Socket | undefined,
   streamRef: MutableRefObject<MediaStream | undefined>,
   isVideoOn: boolean,
   setIsVideoOn: (isVideoOn: boolean) => void,
@@ -22,6 +19,5 @@ export const toggleVideoOnOff = (
   if (streamRef.current) {
     streamRef.current.getVideoTracks()[0].enabled = isVideoOn;
     setIsVideoOn(isVideoOn);
-    socket?.emit("peerVideo", { debateId, isVideoOn });
   }
 };

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3001",
     "lint": "next lint"
   },
   "dependencies": {

--- a/pages/debates/debateroom/[debateId].tsx
+++ b/pages/debates/debateroom/[debateId].tsx
@@ -13,9 +13,5 @@ export default function Debateroom() {
     socketRef.current = io(`${process.env.NEXT_PUBLIC_API_URL}`);
   }, []);
 
-  return (
-    <>
-      <Room debateId={debateId} socket={socketRef.current} />
-    </>
-  );
+  return <Room debateId={debateId} socket={socketRef.current} />;
 }


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->

 - 자신의 차례일 때 공유 화면만 크게 배치
 - 공유 대상의 비율에 따라 그려지는 비율 조정
 - 차례를 boolean에서 string으로 변경 (차례를 3가지로 구분하기 위해)
 - 그리기 색상을 color 객체로 관리

![screenshare](https://user-images.githubusercontent.com/84524514/170199896-1c5ff99a-16f4-4596-a8db-1cad6027fc40.gif)

- 클라이언트 포트 3000에서 3001로 변경
