### PR TITLE
차례에 맞는 오디오 및 화면 공유

### DIFF
--- a/components/debateroom/Buttons.tsx
+++ b/components/debateroom/Buttons.tsx
@@ -17,6 +17,8 @@ export default function Buttons({
   isReady,
   setIsReady,
   isStart,
+  turn,
+  isPros,
 }: Pick<
   IDebateroomProps,
   | "peer"
@@ -32,24 +34,44 @@ export default function Buttons({
   | "isReady"
   | "setIsReady"
   | "isStart"
+  | "turn"
+  | "isPros"
 >) {
+  const checkAudioDisable = () => {
+    if (turn === "notice") return true;
+    if (isPros && turn === "cons") return true;
+    if (!isPros && turn === "pros") return true;
+    return false;
+  };
+
+  const checkScreenDisable = () => {
+    if (isScreenOn) return true;
+    if (isPros && turn === "cons") return true;
+    if (!isPros && turn === "pros") return true;
+    return false;
+  };
+
   return (
     <div>
-      <button
-        onClick={() =>
-          toggleAudio(streamRef, isAudioOn ? false : true, setIsAudioOn)
-        }
-      >
-        {isAudioOn ? "AudioOff" : "AudioOn"}
-      </button>
+      {checkAudioDisable() ? (
+        "AudioOff"
+      ) : (
+        <button
+          onClick={() =>
+            toggleAudio(streamRef, isAudioOn ? false : true, setIsAudioOn)
+          }
+        >
+          {isAudioOn ? "AudioOn" : "AudioOff"}
+        </button>
+      )}
       <button
         onClick={() =>
           toggleVideo(streamRef, isVideoOn ? false : true, setIsVideoOn)
         }
       >
-        {isVideoOn ? "VideoOff" : "VideoOn"}
+        {isVideoOn ? "VideoOn" : "VideoOff"}
       </button>
-      {isScreenOn ? null : (
+      {checkScreenDisable() ? null : (
         <button
           onClick={() =>
             screenShare(

--- a/components/debateroom/Canvas.tsx
+++ b/components/debateroom/Canvas.tsx
@@ -18,6 +18,7 @@ export default function Canvas({
   isPeerScreenOn,
   dummy,
   isPros,
+  turn,
 }: Pick<
   IDebateroomProps,
   | "peer"
@@ -32,6 +33,7 @@ export default function Canvas({
   | "isPeerScreenOn"
   | "dummy"
   | "isPros"
+  | "turn"
 >) {
   const blobsRef = useRef<Blob[]>([]);
   const [drawStart, drawStop] = useSetInterval(
@@ -47,6 +49,7 @@ export default function Canvas({
         isPeerScreenOn,
         dummy,
         isPros,
+        turn,
       ),
     1000 / 30,
   );

--- a/components/debateroom/Canvas.tsx
+++ b/components/debateroom/Canvas.tsx
@@ -18,7 +18,6 @@ export default function Canvas({
   isPeerScreenOn,
   dummy,
   isPros,
-  turn,
 }: Pick<
   IDebateroomProps,
   | "peer"
@@ -33,7 +32,6 @@ export default function Canvas({
   | "isPeerScreenOn"
   | "dummy"
   | "isPros"
-  | "turn"
 >) {
   const blobsRef = useRef<Blob[]>([]);
   const [drawStart, drawStop] = useSetInterval(
@@ -49,7 +47,6 @@ export default function Canvas({
         isPeerScreenOn,
         dummy,
         isPros,
-        turn,
       ),
     1000 / 30,
   );

--- a/components/debateroom/Room.tsx
+++ b/components/debateroom/Room.tsx
@@ -82,12 +82,11 @@ export default function Room({ debateId, socket }: IRoomProps) {
       peerVideoRef,
       setIsPeerVideoOn,
       setIsPeerScreenOn,
-      isStart,
       setIsStart,
       setTurn,
       dummy.topic,
     );
-  }, [debateId, socket, reConnect, isStart, dummy.topic]);
+  }, [debateId, socket, reConnect, dummy.topic]);
 
   //*- Socket and WebRTC 연결 해제
   useEffect(() => {

--- a/components/debateroom/Room.tsx
+++ b/components/debateroom/Room.tsx
@@ -96,9 +96,7 @@ export default function Room({ debateId, socket }: IRoomProps) {
       setReconnect,
       peer,
       setPeer,
-      streamRef,
       peerStreamRef,
-      videoRef,
       peerVideoRef,
       screenStreamRef,
       setIsPeerVideoOn,
@@ -124,8 +122,6 @@ export default function Room({ debateId, socket }: IRoomProps) {
   useEffect(() => {
     toggleVideo(streamRef, false, setIsAudioOn);
   }, []);
-
-  console.log("재랜더링 테스트"); //!
 
   return (
     <div>

--- a/components/debateroom/types.ts
+++ b/components/debateroom/types.ts
@@ -36,9 +36,11 @@ export interface IDebateroomProps {
   setIsReady: (params: boolean) => void;
   isStart: boolean;
   setIsStart: (params: boolean) => void;
-  turn: "notice" | "pros" | "cons" | "prosCross" | "consCross";
+  turn: "none" | "notice" | "pros" | "cons" | "prosCross" | "consCross";
   setIsTurn: Dispatch<
-    SetStateAction<"notice" | "pros" | "cons" | "prosCross" | "consCross">
+    SetStateAction<
+      "none" | "notice" | "pros" | "cons" | "prosCross" | "consCross"
+    >
   >;
   //! 임시 타입
   dummy: IDummy;

--- a/components/debateroom/types.ts
+++ b/components/debateroom/types.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from "react";
+import { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { Socket } from "socket.io-client";
 import Peer from "simple-peer";
 
@@ -7,9 +7,9 @@ export interface IDebateroomProps {
   socket: MutableRefObject<Socket | undefined>;
   //*- WebRTC 타입
   reConnect: boolean;
-  setReconnect: (reConnect: boolean) => void;
+  setReconnect: (params: boolean) => void;
   peer: Peer.Instance | undefined;
-  setPeer: (peer: Peer.Instance | undefined) => void;
+  setPeer: (params: Peer.Instance | undefined) => void;
   //*- 캔버스 타입
   canvasRef: MutableRefObject<HTMLCanvasElement | null>;
   //*- 녹화 타입
@@ -22,24 +22,24 @@ export interface IDebateroomProps {
   peerVideoRef: MutableRefObject<HTMLVideoElement | null>;
   screenStreamRef: MutableRefObject<MediaStream | undefined>;
   isAudioOn: boolean;
-  setIsAudioOn: (isAudioOn: boolean) => void;
+  setIsAudioOn: (params: boolean) => void;
   isVideoOn: boolean;
-  setIsVideoOn: (isVideoOn: boolean) => void;
+  setIsVideoOn: (params: boolean) => void;
   isPeerVideoOn: boolean;
-  setIsPeerVideoOn: (isVideoOn: boolean) => void;
+  setIsPeerVideoOn: (params: boolean) => void;
   isScreenOn: boolean;
-  setIsScreenOn: (isScreenON: boolean) => void;
+  setIsScreenOn: (params: boolean) => void;
   isPeerScreenOn: boolean;
-  setIsPeerScreenOn: (isScreenON: boolean) => void;
+  setIsPeerScreenOn: (params: boolean) => void;
   //*- 토론 타입
   isReady: boolean;
-  setIsReady: (isReady: boolean) => void;
+  setIsReady: (params: boolean) => void;
   isStart: boolean;
-  setIsStart: (isStart: boolean) => void;
+  setIsStart: (params: boolean) => void;
   turn: "notice" | "pros" | "cons" | "prosCross" | "consCross";
-  setIsTurn: (
-    turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
-  ) => void;
+  setIsTurn: Dispatch<
+    SetStateAction<"notice" | "pros" | "cons" | "prosCross" | "consCross">
+  >;
   //! 임시 타입
   dummy: IDummy;
   isPros: boolean;

--- a/components/debateroom/types.ts
+++ b/components/debateroom/types.ts
@@ -36,6 +36,10 @@ export interface IDebateroomProps {
   setIsReady: (isReady: boolean) => void;
   isStart: boolean;
   setIsStart: (isStart: boolean) => void;
+  turn: "notice" | "pros" | "cons" | "prosCross" | "consCross";
+  setIsTurn: (
+    turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
+  ) => void;
   //! 임시 타입
   dummy: IDummy;
   isPros: boolean;
@@ -46,5 +50,4 @@ export interface IDummy {
   topic: string;
   prosName: string;
   consName: string;
-  prosTurn: "none" | "turn" | "false";
 }

--- a/components/debateroom/utils/draw.ts
+++ b/components/debateroom/utils/draw.ts
@@ -83,12 +83,14 @@ export const drawContents = (
   isPeerScreenOn: boolean,
   dummy: IDummy,
   isPros: boolean,
+  turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
 ) => {
   // * Common Bg
   drawSquare(canvasRef, color.white, 0, 80, 1280, 640);
 
+  //! 로직 변경 필요
   // * My screen share
-  if (isScreenOn && String(isPros) === dummy.prosTurn) {
+  if (isScreenOn && String(isPros) === turn) {
     if (videoRef.current) {
       drawSquare(canvasRef, color.black, 0, 80, 1280, 640);
       const [w, h] = resize(videoRef.current);
@@ -97,7 +99,7 @@ export const drawContents = (
         ?.drawImage(videoRef.current, 640 - w / 2, 440 - h / 2, w, h);
     }
     // * Peer screen share
-  } else if (isPeerScreenOn && String(!isPros) === dummy.prosTurn) {
+  } else if (isPeerScreenOn && String(!isPros) === turn) {
     if (peerVideoRef.current) {
       drawSquare(canvasRef, color.black, 0, 80, 1280, 640);
       const [w, h] = resize(peerVideoRef.current);
@@ -173,17 +175,18 @@ export const drawContents = (
 export const drawNotice = (
   canvasRef: MutableRefObject<HTMLCanvasElement | null>,
   debateData: IDebateData,
+  topic: string,
+  turn: string,
 ) => {
   const notice =
-    debateData.timer < 0
+    debateData.turn === 0
+      ? `${topic} ( ${debateData.timer}초 후 시작 )`
+      : debateData.timer < 0
       ? debateData.notice
       : `${debateData.notice} ( ${debateData.timer}초 )`;
-  // const turn =
-  //   debateData.turn === (1 | 4 | 5)
-  //     ? "pros"
-  //     : debateData.turn === (2 | 3 | 6)
-  //     ? "cons"
-  //     : "none";
-  drawSquare(canvasRef, color.black, 0, 0, 1280, 80);
+  let bgColor = color.black;
+  if (turn === "pros" || turn === "prosCross") bgColor = color.pros;
+  if (turn === "cons" || turn === "consCross") bgColor = color.cons;
+  drawSquare(canvasRef, bgColor, 0, 0, 1280, 80);
   drawText(canvasRef, color.white, "normal 28px san-serif", notice, 640, 50);
 };

--- a/components/debateroom/utils/draw.ts
+++ b/components/debateroom/utils/draw.ts
@@ -83,14 +83,13 @@ export const drawContents = (
   isPeerScreenOn: boolean,
   dummy: IDummy,
   isPros: boolean,
-  turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
+  // turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
 ) => {
   // * Common Bg
   drawSquare(canvasRef, color.white, 0, 80, 1280, 640);
 
-  //! 로직 변경 필요
   // * My screen share
-  if (isScreenOn && String(isPros) === turn) {
+  if (isScreenOn) {
     if (videoRef.current) {
       drawSquare(canvasRef, color.black, 0, 80, 1280, 640);
       const [w, h] = resize(videoRef.current);
@@ -99,7 +98,7 @@ export const drawContents = (
         ?.drawImage(videoRef.current, 640 - w / 2, 440 - h / 2, w, h);
     }
     // * Peer screen share
-  } else if (isPeerScreenOn && String(!isPros) === turn) {
+  } else if (isPeerScreenOn) {
     if (peerVideoRef.current) {
       drawSquare(canvasRef, color.black, 0, 80, 1280, 640);
       const [w, h] = resize(peerVideoRef.current);

--- a/components/debateroom/utils/draw.ts
+++ b/components/debateroom/utils/draw.ts
@@ -83,7 +83,6 @@ export const drawContents = (
   isPeerScreenOn: boolean,
   dummy: IDummy,
   isPros: boolean,
-  // turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
 ) => {
   // * Common Bg
   drawSquare(canvasRef, color.white, 0, 80, 1280, 640);
@@ -175,7 +174,13 @@ export const drawNotice = (
   canvasRef: MutableRefObject<HTMLCanvasElement | null>,
   debateData: IDebateData,
   topic: string,
-  turn: string,
+  turn:
+    | "none"
+    | "notice"
+    | "pros"
+    | "cons"
+    | "prosCross"
+    | "consCross" = "notice",
 ) => {
   const notice =
     debateData.turn === 0

--- a/components/debateroom/utils/screenShare.ts
+++ b/components/debateroom/utils/screenShare.ts
@@ -41,3 +41,23 @@ export const screenShare = async (
     console.log(err);
   }
 };
+
+export const offScreen = (
+  peer: Peer.Instance | undefined,
+  streamRef: MutableRefObject<MediaStream | undefined>,
+  videoRef: MutableRefObject<HTMLVideoElement | null>,
+  screenStreamRef: MutableRefObject<MediaStream | undefined>,
+  setIsScreenOn: (params: boolean) => void,
+) => {
+  if (streamRef.current && videoRef.current && screenStreamRef.current) {
+    peer?.replaceTrack(
+      screenStreamRef.current.getVideoTracks()[0],
+      streamRef.current.getVideoTracks()[0],
+      streamRef.current,
+    );
+    screenStreamRef.current.getTracks()[0].stop();
+    videoRef.current.srcObject = streamRef.current;
+    setIsScreenOn(false);
+    screenStreamRef.current = undefined;
+  }
+};

--- a/components/debateroom/utils/screenShare.ts
+++ b/components/debateroom/utils/screenShare.ts
@@ -6,14 +6,13 @@ export const screenShare = async (
   streamRef: MutableRefObject<MediaStream | undefined>,
   videoRef: MutableRefObject<HTMLVideoElement | null>,
   screenStreamRef: MutableRefObject<MediaStream | undefined>,
-  setIsScreenOn: (isOn: boolean) => void,
+  setIsScreenOn: (params: boolean) => void,
 ) => {
   try {
     const screenStream = await navigator.mediaDevices.getDisplayMedia({
       video: true,
       audio: false,
     });
-    screenStreamRef.current = screenStream;
 
     if (streamRef.current && videoRef.current) {
       peer?.replaceTrack(
@@ -23,6 +22,7 @@ export const screenShare = async (
       );
       videoRef.current.srcObject = screenStream;
       setIsScreenOn(true);
+      screenStreamRef.current = screenStream;
     }
 
     screenStream.getTracks()[0].onended = () => {

--- a/components/debateroom/utils/simple-peer.ts
+++ b/components/debateroom/utils/simple-peer.ts
@@ -5,7 +5,7 @@ import Peer from "simple-peer";
 export const connectHostPeer = (
   debateId: string | string[],
   socket: MutableRefObject<Socket | undefined>,
-  setPeer: (peer: Peer.Instance | undefined) => void,
+  setPeer: (params: Peer.Instance | undefined) => void,
   streamRef: MutableRefObject<MediaStream | undefined>,
   peerStreamRef: MutableRefObject<MediaStream | undefined>,
   peerVideoRef: MutableRefObject<HTMLVideoElement | null>,
@@ -40,7 +40,7 @@ export const connectHostPeer = (
   });
 
   simplePeer.on("error", (err) => {
-    console.log(err); //!
+    console.log(err);
   });
 
   socket.current?.on("answer", (signal: Peer.SignalData) => {
@@ -51,7 +51,7 @@ export const connectHostPeer = (
 export const connectGuestPeer = (
   debateId: string | string[],
   socket: MutableRefObject<Socket | undefined>,
-  setPeer: (peer: Peer.Instance | undefined) => void,
+  setPeer: (params: Peer.Instance | undefined) => void,
   streamRef: MutableRefObject<MediaStream | undefined>,
   peerStreamRef: MutableRefObject<MediaStream | undefined>,
   peerVideoRef: MutableRefObject<HTMLVideoElement | null>,
@@ -77,7 +77,7 @@ export const connectGuestPeer = (
   });
 
   simplePeer.on("error", (err) => {
-    console.log(err); //!
+    console.log(err);
   });
 
   simplePeer.signal(signal);

--- a/components/debateroom/utils/toggle.ts
+++ b/components/debateroom/utils/toggle.ts
@@ -3,7 +3,7 @@ import { MutableRefObject } from "react";
 export const toggleAudio = (
   streamRef: MutableRefObject<MediaStream | undefined>,
   isAudioOn: boolean,
-  setIsAudioOn: (isMute: boolean) => void,
+  setIsAudioOn: (params: boolean) => void,
 ) => {
   if (streamRef.current) {
     streamRef.current.getAudioTracks()[0].enabled = isAudioOn;
@@ -14,7 +14,7 @@ export const toggleAudio = (
 export const toggleVideo = (
   streamRef: MutableRefObject<MediaStream | undefined>,
   isVideoOn: boolean,
-  setIsVideoOn: (isVideoOn: boolean) => void,
+  setIsVideoOn: (params: boolean) => void,
 ) => {
   if (streamRef.current) {
     streamRef.current.getVideoTracks()[0].enabled = isVideoOn;
@@ -24,7 +24,7 @@ export const toggleVideo = (
 
 export const toggleReady = (
   isReady: boolean,
-  setIsReady: (isReady: boolean) => void,
+  setIsReady: (params: boolean) => void,
 ) => {
   setIsReady(isReady);
 };

--- a/components/debateroom/utils/webSocket.ts
+++ b/components/debateroom/utils/webSocket.ts
@@ -18,9 +18,9 @@ export const wsConnect = (
   setIsPeerVideoOn: (params: boolean) => void,
   setIsPeerScreenOn: (params: boolean) => void,
   setIsStart: (params: boolean) => void,
-  setTurn: Dispatch<
-    SetStateAction<"notice" | "pros" | "cons" | "prosCross" | "consCross">
-  >,
+  setTurn: (
+    params: "notice" | "pros" | "cons" | "prosCross" | "consCross",
+  ) => void,
   topic: string,
 ) => {
   console.log("연결"); //!
@@ -43,7 +43,7 @@ export const wsConnect = (
 
     // * 방 입장 거절
     socket.current.on("overcapacity", () => {
-      console.log("overcapacity"); //! 추가 처리 필요
+      console.log("overcapacity"); //!
     });
 
     // * WebRTC 연결
@@ -98,7 +98,7 @@ export const wsConnect = (
     drawNotice(
       canvasRef,
       {
-        notice: isStart ? "곧 토론이 재시작 됩니다." : topic,
+        notice: topic,
         turn: -1,
         timer: -1,
       },
@@ -112,17 +112,15 @@ export const wsConnect = (
 export const wsDisconnect = (
   socket: MutableRefObject<Socket | undefined>,
   reConnect: boolean,
-  setReconnect: (reConnect: boolean) => void,
+  setReconnect: (params: boolean) => void,
   peer: Peer.Instance | undefined,
-  setPeer: (peer: Peer.Instance | undefined) => void,
-  streamRef: MutableRefObject<MediaStream | undefined>,
+  setPeer: (params: Peer.Instance | undefined) => void,
   peerStreamRef: MutableRefObject<MediaStream | undefined>,
-  videoRef: MutableRefObject<HTMLVideoElement | null>,
   peerVideoRef: MutableRefObject<HTMLVideoElement | null>,
   screenStreamRef: MutableRefObject<MediaStream | undefined>,
-  setIsPeerVideoOn: (isVideoOn: boolean) => void,
-  setIsScreenOn: (isScreenON: boolean) => void,
-  setIsPeerScreenOn: (isScreenON: boolean) => void,
+  setIsPeerVideoOn: (params: boolean) => void,
+  setIsScreenOn: (params: boolean) => void,
+  setIsPeerScreenOn: (params: boolean) => void,
 ) => {
   socket.current?.on("peerDisconnect", () => {
     peer?.destroy();
@@ -131,9 +129,7 @@ export const wsDisconnect = (
     socket.current?.disconnect();
     socket.current = io(`${process.env.NEXT_PUBLIC_API_URL}`);
 
-    streamRef.current = undefined;
     peerStreamRef.current = undefined;
-    if (videoRef.current) videoRef.current.srcObject = null;
     if (peerVideoRef.current) peerVideoRef.current.srcObject = null;
     if (screenStreamRef.current) {
       screenStreamRef.current.getTracks()[0].stop();

--- a/components/debateroom/utils/webSocket.ts
+++ b/components/debateroom/utils/webSocket.ts
@@ -9,21 +9,21 @@ import { IDebateData, drawNotice } from "./draw";
 export const wsConnect = (
   debateId: string | string[] | undefined,
   socket: MutableRefObject<Socket | undefined>,
-  setPeer: (peer: Peer.Instance | undefined) => void,
+  setPeer: (params: Peer.Instance | undefined) => void,
   canvasRef: MutableRefObject<HTMLCanvasElement | null>,
   streamRef: MutableRefObject<MediaStream | undefined>,
   peerStreamRef: MutableRefObject<MediaStream | undefined>,
   videoRef: MutableRefObject<HTMLVideoElement | null>,
   peerVideoRef: MutableRefObject<HTMLVideoElement | null>,
-  setIsPeerVideoOn: (isVideoOn: boolean) => void,
-  setIsPeerScreenOn: (isScreenON: boolean) => void,
-  isStart: boolean,
-  setIsStart: (isStart: boolean) => void,
-  setTurn: (
-    turn: "notice" | "pros" | "cons" | "prosCross" | "consCross",
-  ) => void,
+  setIsPeerVideoOn: (params: boolean) => void,
+  setIsPeerScreenOn: (params: boolean) => void,
+  setIsStart: (params: boolean) => void,
+  setTurn: Dispatch<
+    SetStateAction<"notice" | "pros" | "cons" | "prosCross" | "consCross">
+  >,
   topic: string,
 ) => {
+  console.log("연결"); //!
   if (debateId && socket.current) {
     // * 사용자 미디어 획득
     navigator.mediaDevices

--- a/components/debateroom/utils/webSocket.ts
+++ b/components/debateroom/utils/webSocket.ts
@@ -19,7 +19,7 @@ export const wsConnect = (
   setIsPeerScreenOn: (params: boolean) => void,
   setIsStart: (params: boolean) => void,
   setTurn: (
-    params: "notice" | "pros" | "cons" | "prosCross" | "consCross",
+    params: "none" | "notice" | "pros" | "cons" | "prosCross" | "consCross",
   ) => void,
   topic: string,
 ) => {
@@ -84,8 +84,13 @@ export const wsConnect = (
     });
 
     socket.current.on("debateProgress", (debateData: IDebateData) => {
-      let turn: "notice" | "pros" | "cons" | "prosCross" | "consCross" =
-        "notice";
+      let turn:
+        | "none"
+        | "notice"
+        | "pros"
+        | "cons"
+        | "prosCross"
+        | "consCross" = "notice";
       if (debateData.turn === 1 || debateData.turn === 5) turn = "pros";
       if (debateData.turn === 3 || debateData.turn === 6) turn = "cons";
       if (debateData.turn === 4) turn = "prosCross";
@@ -103,7 +108,7 @@ export const wsConnect = (
         timer: -1,
       },
       topic,
-      "notice",
+      "none",
     );
   }
 };


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->

- 준비 후 토론 시작 시 발생하는 문제 해결
- isStart가 변하면서 wsConnect가 재실행 되는 것이 문제였음

<img width="1440" alt="isStart Error" src="https://user-images.githubusercontent.com/84524514/171025129-d7369b84-f381-4dfa-a0fd-f791993d5b5e.png">

- 상대방이 화면 공유 시 화면 공유 끄기
- 상대의 발언 시간에는 오디오 버튼 및 화면 공유 버튼 비활성화
- 차례 전환 시 차례에 맞게 오디오 및 화면 공유 끄기
- 위의 기능들은 발언권의 보장을 위해서 추가

![debate-turn](https://user-images.githubusercontent.com/84524514/171024576-1de410a5-9b50-4551-b949-45748871d9af.gif)


