### PR TITLE
경고음 시간 변경

### DIFF
--- a/components/debateroom/utils/webSocket.ts
+++ b/components/debateroom/utils/webSocket.ts
@@ -97,7 +97,7 @@ export const wsConnect = (
       if (debateData.turn === 2) turn = "consCross";
       setTurn(turn);
       drawNotice(canvasRef, debateData, topic, turn);
-      if (debateData.timer < 4) beep();
+      if (debateData.timer === 10 || debateData.timer === 3) beep();
     });
 
     // * 기본 공지


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->

- 경고음 시간을 3초 이하에서 10초와 3초로 변경
- 10초는 발언을 마무리 하라는 신호
- 3초는 차례가 곧 종료 된다는 신호