### PR TITLE
네트워크 에러 시 에러 메시지 타입 문제 해결

### DIFF
--- a/api/users.ts
+++ b/api/users.ts
@@ -37,7 +37,8 @@ export const login = (
       if (callback) callback();
     })
     .catch((err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      console.log(err);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     });
 };
 

--- a/components/debates/debates/DebatesContainer.tsx
+++ b/components/debates/debates/DebatesContainer.tsx
@@ -117,7 +117,7 @@ export default function DebatesContainer({
                   }
                 }}
               >
-                x
+                ☓
               </div>
             </div>
           ) : (
@@ -142,7 +142,7 @@ export default function DebatesContainer({
                   }
                 }}
               >
-                v
+                ⚲
               </div>
             </div>
           )}

--- a/utils/queries/comments.ts
+++ b/utils/queries/comments.ts
@@ -41,7 +41,7 @@ export const usePostComment = (
       queryClient.invalidateQueries([queryStr.comments, `${debateId}`]);
     },
     onError: (err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -57,7 +57,7 @@ export const usePatchComment = (
       queryClient.invalidateQueries([queryStr.comments, `${debateId}`]);
     },
     onError: (err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -73,7 +73,7 @@ export const useDeleteComment = (
       queryClient.invalidateQueries([queryStr.comments, `${debateId}`]);
     },
     onError: (err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };

--- a/utils/queries/debates.ts
+++ b/utils/queries/debates.ts
@@ -71,7 +71,7 @@ export const usePostDebate = (
       router.push(`/debates`);
     },
     onError: (err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -114,7 +114,7 @@ export const usePatchDebate = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -131,7 +131,7 @@ export const useDeleteDebate = (
       router.push(`/debates`);
     },
     onError: (err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };

--- a/utils/queries/factchecks.ts
+++ b/utils/queries/factchecks.ts
@@ -27,7 +27,7 @@ export const usePostFactcheck = (
       queryClient.invalidateQueries([queryStr.debates, `${debateId}`]);
     },
     onError: (err: AxiosError<{ message: string }>) => {
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -71,7 +71,7 @@ export const usePatchFactcheck = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -108,7 +108,7 @@ export const useDeleteFactcheck = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };

--- a/utils/queries/hearts.ts
+++ b/utils/queries/hearts.ts
@@ -79,7 +79,7 @@ export const usePostHeart = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -137,7 +137,7 @@ export const useDeleteHeart = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };

--- a/utils/queries/votes.ts
+++ b/utils/queries/votes.ts
@@ -95,7 +95,7 @@ export const usePostVote = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };
@@ -165,7 +165,7 @@ export const usePatchVote = (
     },
     onError: (err: AxiosError<{ message: string }>, variables, rollback) => {
       if (rollback) rollback();
-      toast.error(`${err.response?.data.message}`);
+      toast.error(`${err.response?.data?.message || "네트워크 에러 발생"}`);
     },
   });
 };


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->
서버에 문제가 있어서 반환되는 네트워크 에러에는 서버에서 의도적으로 담아서 보내는 에러메시지가 undefined라 발생하는 문제 해결.
대부분의 에러는 서버에서 의도적인 에러 메시지를 담아서 보내므로 undefined일 경우 네트워크 에러라고 판단하고 "네트워크 에러 발생" 메시지를 사용자에게 보여줌.
