### PR TITLE
헤더 개선 및 기타 에러 해결

### DIFF
--- a/components/Header.module.scss
+++ b/components/Header.module.scss
@@ -5,6 +5,7 @@
   padding: 10px;
   max-width: 1200px;
   margin: 0 auto;
+  min-width: 22rem;
   .background {
     width: 100%;
     height: 100%;
@@ -17,13 +18,12 @@
     display: flex;
     font-size: 1.8rem;
     font-weight: bold;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    user-select: none;
+    @include center {
+      justify-content: flex-start;
+    }
+    @include disabledText;
     cursor: pointer;
-    width: 300px;
-    margin: 0 auto;
+    width: 100%;
     .title {
       margin: 0 10px;
     }
@@ -34,11 +34,15 @@
     right: 10px;
     transform: translateY(-50%);
     cursor: pointer;
-    border: 3px solid $c-pros;
-    border-radius: 999px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    @include center {
+      gap: 1rem;
+    }
+    .image_box {
+      border-radius: 100%;
+      background-color: $c-pros;
+      @include center;
+      padding: 3px;
+    }
     & img {
       border-radius: 999px;
     }
@@ -47,7 +51,7 @@
       position: absolute;
       top: 40px;
       right: 0;
-      background-color: #fff;
+      background-color: $c-white;
       border: 1px solid $c-pros;
       border-radius: 10px;
       overflow: hidden;
@@ -58,16 +62,62 @@
       padding: 10px;
       &:hover {
         background-color: $c-pros;
-        color: #fff;
+        color: $c-white;
       }
     }
     .sign_btn {
-      background-color: $c-pros;
-      border: none;
-      border-radius: 999px;
-      padding: 10px 20px;
-      color: #fff;
+      @include btn-w(5rem) {
+        border-radius: 9px;
+      }
+      @include btn-c($c-pros, $c-pros, $c-white);
+      &:hover {
+        @include btn-c($c-white, $c-pros, $c-pros);
+      }
       cursor: pointer;
+      &_cut {
+        color: $c-pros;
+        font-weight: 700;
+        width: 2.2rem;
+        height: 2.2rem;
+        @include center;
+        border-radius: 100%;
+        border: 3px solid $c-pros;
+        &:hover {
+          background-color: $c-pros;
+          border: 3px solid $c-pros;
+          color: $c-white;
+        }
+      }
     }
+  }
+}
+
+@include media(480px) {
+  .title {
+    font-size: 1.6rem;
+  }
+}
+
+@include media(450px) {
+  .title {
+    font-size: 1.4rem;
+  }
+}
+
+@include media(430px) {
+  .title {
+    font-size: 1.2rem;
+  }
+}
+
+@include media(410px) {
+  .title {
+    font-size: 1rem;
+  }
+}
+
+@include media(380px) {
+  .title {
+    display: none;
   }
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -35,7 +35,7 @@ export default function Header() {
     setIsSigninModalOpen(false);
   };
 
-  return (
+  return /\/debateroom/.test(router.pathname) ? null : (
     <div className={styles.container}>
       {isSignoutModalOpen ? (
         <ConfirmModal
@@ -89,22 +89,44 @@ export default function Header() {
           </ul>
         ) : null}
         {user.data ? (
-          <Image
-            src={
-              user.data?.profile_image !== "temp default image"
-                ? `${process.env.NEXT_PUBLIC_API_URL}/uploads/${user.data?.profile_image}`
-                : "/images/profiles/default-green.png"
-            }
-            alt="profile_image"
-            width="30"
-            height="30"
-            unoptimized={true}
-            onClick={handleProfileClick}
-          />
+          <>
+            <div
+              className={styles.sign_btn_cut}
+              onClick={() => {
+                router.push("/q&a");
+              }}
+            >
+              ?
+            </div>
+            <div className={styles.image_box}>
+              <Image
+                src={
+                  user.data?.profile_image !== "temp default image"
+                    ? `${process.env.NEXT_PUBLIC_API_URL}/uploads/${user.data?.profile_image}`
+                    : "/images/profiles/default-green.png"
+                }
+                alt="profile_image"
+                width="30"
+                height="30"
+                unoptimized={true}
+                onClick={handleProfileClick}
+              />
+            </div>
+          </>
         ) : (
-          <button className={styles.sign_btn} onClick={handleSigninBtnClick}>
-            로그인
-          </button>
+          <>
+            <div
+              className={styles.sign_btn}
+              onClick={() => {
+                router.push("/q&a");
+              }}
+            >
+              {"Q & A"}
+            </div>
+            <div className={styles.sign_btn} onClick={handleSigninBtnClick}>
+              로그인
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,15 +2,21 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import toast from "react-hot-toast";
+import { useQueryClient } from "react-query";
+
 import { useGetUser } from "../utils/queries/users";
-import ConfirmModal from "./common/modal/ConfirmModal";
+import { queryStr } from "../utils/queries";
 import styles from "./Header.module.scss";
 
+import ConfirmModal from "./common/modal/ConfirmModal";
+
 export default function Header() {
-  const user = useGetUser();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [isSigninModalOpen, setIsSigninModalOpen] = useState(false);
   const [isSignoutModalOpen, setIsSignoutModalOpen] = useState(false);
+
+  const user = useGetUser();
 
   const handleLogoClick = () => {
     router.push("/");
@@ -43,7 +49,7 @@ export default function Header() {
           secondFunc={() => {
             setIsSignoutModalOpen(false);
             window.localStorage.removeItem("debate-ducks-token");
-            router.push("/");
+            queryClient.setQueryData([queryStr.users], () => null);
             toast.success("로그아웃 되었습니다!");
           }}
         />

--- a/components/common/modal/ChangePasswordModal.module.scss
+++ b/components/common/modal/ChangePasswordModal.module.scss
@@ -23,7 +23,7 @@
   border-radius: 9px;
   font-size: 1rem;
   text-align: center;
-  min-width: 20rem;
+  min-width: 22rem;
   z-index: 9999;
 }
 

--- a/components/common/modal/ConfirmModal.module.scss
+++ b/components/common/modal/ConfirmModal.module.scss
@@ -23,7 +23,7 @@
   border-radius: 9px;
   font-size: 1rem;
   text-align: center;
-  min-width: 20rem;
+  min-width: 22rem;
   z-index: 9;
 }
 

--- a/components/common/modal/SignInModal.module.scss
+++ b/components/common/modal/SignInModal.module.scss
@@ -23,7 +23,7 @@
   border-radius: 9px;
   font-size: 1rem;
   text-align: center;
-  min-width: 20rem;
+  min-width: 22rem;
   z-index: 9;
 }
 

--- a/components/debates/CreateOrEdit.module.scss
+++ b/components/debates/CreateOrEdit.module.scss
@@ -1,7 +1,7 @@
 @import "../../styles/variable.scss";
 
 .outer {
-  min-width: 20rem;
+  min-width: 22rem;
   @include center {
     flex-direction: column;
   }

--- a/components/debates/debate/Factcheck.tsx
+++ b/components/debates/debate/Factcheck.tsx
@@ -102,93 +102,99 @@ export default function Factcheck({
               }개)`}
         </div>
         <div className={styles.factchecks_box}>
-          {debate.data?.factchecks
-            .filter((factcheck) => factcheck.pros === isPros)
-            .map((factcheck) => (
-              <div className={styles.factcheck} key={factcheck.id}>
-                {isEditOn && factcheckId === factcheck.id ? (
-                  <>
-                    <textarea
-                      className={`${styles.description} ${styles.input}`}
-                      {...descriptionEdithInput.attribute}
-                    />
-                    <div className={styles.under_box}>
-                      <input
-                        className={`${styles.a} ${styles.input}`}
-                        {...referenceEditInput.attribute}
+          {debate.data && debate.data?.factchecks.length !== 0 ? (
+            debate.data?.factchecks
+              .filter((factcheck) => factcheck.pros === isPros)
+              .map((factcheck) => (
+                <div className={styles.factcheck} key={factcheck.id}>
+                  {isEditOn && factcheckId === factcheck.id ? (
+                    <>
+                      <textarea
+                        className={`${styles.description} ${styles.input}`}
+                        {...descriptionEdithInput.attribute}
                       />
-                      <button
-                        className={`${styles.btn} ${styles.btn_pros}`}
-                        onClick={() => setIsEditOn(false)}
-                      >
-                        취소
-                      </button>
-                      <button
-                        className={`${styles.btn} ${styles.btn_cons}`}
-                        onClick={() =>
-                          handleEdit(
-                            factcheck.description,
-                            factcheck.reference_url,
-                          )
-                        }
-                      >
-                        수정
-                      </button>
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <pre className={styles.description}>
-                      {factcheck.description}
-                    </pre>
-                    <div className={styles.under_box}>
-                      <div
-                        className={`${isPros ? styles.pros : styles.cons} ${
-                          styles.a
-                        }`}
-                      >
-                        <a
-                          href={factcheck.reference_url}
-                          target="_blank"
-                          rel="noreferrer"
+                      <div className={styles.under_box}>
+                        <input
+                          className={`${styles.a} ${styles.input}`}
+                          {...referenceEditInput.attribute}
+                        />
+                        <button
+                          className={`${styles.btn} ${styles.btn_pros}`}
+                          onClick={() => setIsEditOn(false)}
                         >
-                          {factcheck.reference_url}
-                        </a>
+                          취소
+                        </button>
+                        <button
+                          className={`${styles.btn} ${styles.btn_cons}`}
+                          onClick={() =>
+                            handleEdit(
+                              factcheck.description,
+                              factcheck.reference_url,
+                            )
+                          }
+                        >
+                          수정
+                        </button>
                       </div>
-                      {checkAuthor() ? (
-                        <>
-                          <div
-                            className={`${styles.btn} ${styles.btn_pros}`}
-                            onClick={() => {
-                              setFactcheckId(factcheck.id);
-                              descriptionEdithInput.setValue(
-                                factcheck.description,
-                              );
-                              referenceEditInput.setValue(
-                                factcheck.reference_url,
-                              );
-                              setIsEditOn(true);
-                            }}
+                    </>
+                  ) : (
+                    <>
+                      <pre className={styles.description}>
+                        {factcheck.description}
+                      </pre>
+                      <div className={styles.under_box}>
+                        <div
+                          className={`${isPros ? styles.pros : styles.cons} ${
+                            styles.a
+                          }`}
+                        >
+                          <a
+                            href={factcheck.reference_url}
+                            target="_blank"
+                            rel="noreferrer"
                           >
-                            수정
-                          </div>
-                          <div
-                            className={`${styles.btn} ${styles.btn_cons}`}
-                            onClick={() => {
-                              setFactcheckId(factcheck.id);
-                              setIsDeleteModalOn(true);
-                            }}
-                          >
-                            삭제
-                          </div>
-                        </>
-                      ) : null}
-                    </div>
-                  </>
-                )}
-                <div className={styles.line}></div>
-              </div>
-            ))}
+                            {factcheck.reference_url}
+                          </a>
+                        </div>
+                        {checkAuthor() ? (
+                          <>
+                            <div
+                              className={`${styles.btn} ${styles.btn_pros}`}
+                              onClick={() => {
+                                setFactcheckId(factcheck.id);
+                                descriptionEdithInput.setValue(
+                                  factcheck.description,
+                                );
+                                referenceEditInput.setValue(
+                                  factcheck.reference_url,
+                                );
+                                setIsEditOn(true);
+                              }}
+                            >
+                              수정
+                            </div>
+                            <div
+                              className={`${styles.btn} ${styles.btn_cons}`}
+                              onClick={() => {
+                                setFactcheckId(factcheck.id);
+                                setIsDeleteModalOn(true);
+                              }}
+                            >
+                              삭제
+                            </div>
+                          </>
+                        ) : null}
+                      </div>
+                    </>
+                  )}
+                  <div className={styles.line}></div>
+                </div>
+              ))
+          ) : (
+            <div className={styles.empty_message}>
+              작성된 팩트체크가 없습니다.
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/components/debates/debate/Factchecks.module.scss
+++ b/components/debates/debate/Factchecks.module.scss
@@ -169,6 +169,14 @@
   }
 }
 
+.empty_message {
+  margin-top: 2rem;
+  width: 100%;
+  text-align: center;
+  font-size: 120%;
+  color: darken($c-gray-dark, 20%);
+}
+
 @include media(750px) {
   .factchecks_outer {
     justify-content: flex-start;

--- a/components/debates/debate/Factchecks.module.scss
+++ b/components/debates/debate/Factchecks.module.scss
@@ -10,7 +10,7 @@
 }
 
 .factchecks_inner {
-  min-width: 20rem;
+  min-width: 22rem;
   width: 45%;
   @include center {
     flex-direction: column;

--- a/components/debates/debate/Vote.module.scss
+++ b/components/debates/debate/Vote.module.scss
@@ -32,7 +32,7 @@
 }
 
 .box_result {
-  background-color: red;
+  background-color: darken($c-gray-dark, 20%);
   width: 60%;
   height: 1rem;
   border-radius: 9px;

--- a/components/debates/debate/Vote.tsx
+++ b/components/debates/debate/Vote.tsx
@@ -47,6 +47,9 @@ export default function Vote({ debateId }: { debateId: number }) {
   };
 
   const calcPercent = (cnt: number) => {
+    if (!debate.data?.vote.prosCnt && !debate.data?.vote.consCnt) {
+      return 50;
+    }
     return (
       (cnt /
         ((debate.data?.vote.prosCnt || 0) + (debate.data?.vote.consCnt || 0))) *

--- a/components/debates/debate/index.module.scss
+++ b/components/debates/debate/index.module.scss
@@ -7,7 +7,7 @@ $m: 5rem;
   @include center {
     flex-direction: column;
   }
-  min-width: 20rem;
+  min-width: 22rem;
   margin-bottom: 5rem;
 }
 

--- a/components/debates/debate/index.module.scss
+++ b/components/debates/debate/index.module.scss
@@ -15,6 +15,7 @@ $m: 5rem;
   position: relative;
   background-color: $c-cons;
   &_bg {
+    position: relative;
     width: 100vw;
     height: 25rem;
     mix-blend-mode: exclusion;

--- a/components/debates/debate/index.tsx
+++ b/components/debates/debate/index.tsx
@@ -1,5 +1,6 @@
+import { useQueryClient } from "react-query";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 
 import { useGetUser } from "../../../utils/queries/users";
@@ -12,6 +13,7 @@ import {
 import { CATEGORIES } from "../../../utils/common/constant";
 import { DMYHM } from "../../../utils/common/formatStrDate";
 import { thousandDigit } from "../../../utils/common/thousandDigit";
+import { queryStr } from "../../../utils/queries";
 import styles from "./index.module.scss";
 
 import CheckSignInModal from "../../common/modal/CheckSignInModal";
@@ -23,6 +25,7 @@ import Comments from "./Comments";
 
 export default function Debate({ debateId }: { debateId: number }) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [isCheckModalOn, setIsCheckModalOn] = useState<boolean>(false);
 
   const user = useGetUser();
@@ -39,6 +42,13 @@ export default function Debate({ debateId }: { debateId: number }) {
   const patchDebate = usePatchDebate(debateId, user.data);
   const postHeart = usePostHeart();
   const deleteHeart = useDeleteHeart();
+
+  useEffect(() => {
+    if (!user.data) {
+      queryClient.setQueryData([queryStr.hearts, `${debateId}`], () => null);
+      queryClient.setQueryData([queryStr.votes, `${debateId}`], () => null);
+    }
+  }, [debateId, queryClient, user.data]);
 
   const handleParticipant = () => {
     if (!user.data) {

--- a/components/debates/debate/index.tsx
+++ b/components/debates/debate/index.tsx
@@ -94,6 +94,7 @@ export default function Debate({ debateId }: { debateId: number }) {
               layout="fill"
               objectFit="cover"
               objectPosition="center"
+              priority={true}
             />
           </div>
           <div className={styles.title_name}>{debate.data?.title}</div>

--- a/components/debates/debates/DebateCard.tsx
+++ b/components/debates/debates/DebateCard.tsx
@@ -42,6 +42,7 @@ export default function DebateCard({
           layout="fill"
           objectFit="cover"
           objectPosition="center"
+          priority={true}
         />
       </div>
       <div className={styles.debaters}>

--- a/components/debates/debates/DebatesCards.module.scss
+++ b/components/debates/debates/DebatesCards.module.scss
@@ -2,7 +2,6 @@
 
 .outer {
   font-size: 0.8rem;
-  margin: 1rem;
   @include center {
     flex-direction: column;
   }

--- a/components/debates/debates/DebatesCards.module.scss
+++ b/components/debates/debates/DebatesCards.module.scss
@@ -6,7 +6,7 @@
   @include center {
     flex-direction: column;
   }
-  min-width: 20rem;
+  min-width: 22rem;
   margin-bottom: 5rem;
 }
 

--- a/components/debates/debates/Filters.module.scss
+++ b/components/debates/debates/Filters.module.scss
@@ -6,7 +6,7 @@
   @include center {
     flex-direction: column;
   }
-  min-width: 20rem;
+  min-width: 22rem;
 }
 
 .container {

--- a/components/debates/debates/Filters.module.scss
+++ b/components/debates/debates/Filters.module.scss
@@ -2,7 +2,7 @@
 
 .outer {
   font-size: 0.8rem;
-  margin: 4rem 1rem 1rem;
+  margin: 3rem 1rem 1rem;
   @include center {
     flex-direction: column;
   }

--- a/components/debates/debates/LikeBtn.module.scss
+++ b/components/debates/debates/LikeBtn.module.scss
@@ -5,7 +5,7 @@
   font-size: 0.8rem;
   margin: 1rem;
   font-weight: 700;
-  min-width: 20rem;
+  min-width: 22rem;
 }
 
 .btn {

--- a/pages/q&a/index.tsx
+++ b/pages/q&a/index.tsx
@@ -1,0 +1,7 @@
+export default function QnA() {
+  return (
+    <div>
+      <h1>준비 중입니다.</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->
### 빈 팩트체크 표시
- 기존 팩트체크
   <img width="1200" alt="기존 팩트체크" src="https://user-images.githubusercontent.com/84524514/184529279-86996629-4056-4198-b8b3-b94a252629c8.png">

- 변경 후 팩트체크
   <img width="1200" alt="변경 후 팩트체크" src="https://user-images.githubusercontent.com/84524514/184529286-c4ccdda0-1036-418a-9b8b-552e6c0d42fa.png">

### 투표 - 0표일 때 처리
- 기존 투표
   <img width="800" alt="기존 투표" src="https://user-images.githubusercontent.com/84524514/184529662-23ab7aca-7f47-45ff-9dae-54582f4c5104.png">

- 변경 후 투표
   <img width="800" alt="변경 후 투표" src="https://user-images.githubusercontent.com/84524514/184529670-63083109-9791-4a82-828b-9c211556896c.png">

### 로그아웃 기능 개선
기존에는 로그아웃 시 로컬 저장소에서 토큰을 지우고, 메인 페이지로 보내주는 방식으로 되어있었습니다. 그래서 변경된 사항이 바로 사용자의 화면에 반영되지 않았습니다.

해당 부분의 개선을 위해 `queryClient.setQueryData([queryStr.users], () => null);` 처리를 해줘서 유저 접어보의 변경이 사용자의 화면에 바로 변경되게 하고, 메인 페이지로 보내는 기능은 필요 없다고 생각해 삭제했습니다.

### 헤더 스타일 변경
- 기존 헤더 (반응형 X)
   <img width="300" alt="기존 헤더" src="https://user-images.githubusercontent.com/84524514/184530147-ee74aa06-be35-43d0-b2e5-27ad7bcbeceb.png">

- 변경 후 헤더 (반응형 O)
   <img width="500" alt="변경 후 헤더1" src="https://user-images.githubusercontent.com/84524514/184530228-f5298494-b3d1-4ff2-97b0-d559a5458cc6.png">
   <img width="400" alt="변경 후 헤더2" src="https://user-images.githubusercontent.com/84524514/184530225-c3fb3891-5923-4a2d-bfd3-196139701f3d.png">
   <img width="500" alt="변경 후 헤더3" src="https://user-images.githubusercontent.com/84524514/184530245-3373c196-bba2-4ada-9794-109627529fe3.png">

### 이미지 경고 해결

이미지 관련 경고들이 떴는데 경고에 해결 방법이 명시되어 있어서 쉽게 해결했다.

1. 이미지에 `priority={true}` 추가
2. 부모 요소에 `position: relative;` 추가

