### PR TITLE
로그인 및 회원가입 개선

### DIFF
--- a/components/Header.module.scss
+++ b/components/Header.module.scss
@@ -22,9 +22,12 @@
       justify-content: flex-start;
     }
     @include disabledText;
-    cursor: pointer;
     width: 100%;
+    .image {
+      cursor: pointer;
+    }
     .title {
+      cursor: pointer;
       margin: 0 10px;
     }
   }
@@ -33,7 +36,6 @@
     top: 50%;
     right: 10px;
     transform: translateY(-50%);
-    cursor: pointer;
     @include center {
       gap: 1rem;
     }
@@ -42,12 +44,14 @@
       background-color: $c-pros;
       @include center;
       padding: 3px;
+      cursor: pointer;
     }
     & img {
       border-radius: 999px;
     }
     z-index: 2;
     .list {
+      cursor: pointer;
       position: absolute;
       top: 40px;
       right: 0;
@@ -75,6 +79,7 @@
       }
       cursor: pointer;
       &_cut {
+        cursor: pointer;
         color: $c-pros;
         font-weight: 700;
         width: 2.2rem;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -63,12 +63,14 @@ export default function Header() {
         ></div>
       ) : null}
       <div className={styles.logo_container} onClick={handleLogoClick}>
-        <Image
-          src="/images/logo/debate-ducks-symbol.svg"
-          alt="logo_image"
-          width="40"
-          height="40"
-        />
+        <div className={styles.image}>
+          <Image
+            src="/images/logo/debate-ducks-symbol.svg"
+            alt="logo_image"
+            width="40"
+            height="40"
+          />
+        </div>
         <h1 className={styles.title}>DEBATE DUCKS</h1>
       </div>
       <div className={styles.profile_container}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,12 +4,14 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { Toaster } from "react-hot-toast";
 import Head from "next/head";
+import { useRouter } from "next/router";
 
 import "../styles/globals.scss";
 
 import Header from "../components/Header";
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -21,12 +23,22 @@ function MyApp({ Component, pageProps }: AppProps) {
         },
       }),
   );
-
   const [isToaster, setIsToaster] = useState<boolean>(false);
 
   useEffect(() => {
     setIsToaster(true);
   }, []);
+
+  useEffect(() => storePathValues, [router.asPath]);
+
+  function storePathValues() {
+    const storage = globalThis?.sessionStorage;
+    if (!storage) return;
+    const prevPath = storage.getItem("currentPath");
+    storage.setItem("prevPath", prevPath || "");
+    storage.setItem("currentPath", globalThis.location.pathname);
+    console.log(storage.getItem("prevPath"), storage.getItem("currentPath"));
+  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -1,17 +1,17 @@
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { ChangeEvent, useState } from "react";
 import { FiEye, FiEyeOff } from "react-icons/fi";
+import { useQueryClient } from "react-query";
+
 import { login } from "../../api/users";
-import { useGetUser } from "../../utils/queries/users";
+import { queryStr } from "../../utils/queries";
 import styles from "./Signin.module.scss";
 
 export default function Signin() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
   const [userInfo, setUserInfo] = useState({ email: "", password: "" });
   const [showPassword, setShowPassword] = useState(false);
-
-  const router = useRouter();
-  const user = useGetUser();
 
   function handleChange(e: ChangeEvent<HTMLInputElement>) {
     const valueType = e.target.name;
@@ -20,10 +20,15 @@ export default function Signin() {
   }
 
   function handleSignin() {
-    console.log(userInfo);
     login(userInfo.email, userInfo.password, () => {
-      router.push("/");
-      user.refetch();
+      queryClient.invalidateQueries([queryStr.users]);
+      const storage = globalThis?.sessionStorage;
+      const link =
+        storage.getItem("prevPath") === "/signin" ||
+        storage.getItem("prevPath") === "/signup"
+          ? "/"
+          : storage.getItem("prevPath") || "/";
+      router.push(link);
     });
   }
 
@@ -83,9 +88,13 @@ export default function Signin() {
         )}
         <div className={styles.signup}>
           <div>아직 회원이 아니신가요?</div>
-          <Link href="/signup">
+          <div
+            onClick={() => {
+              router.push("/signup");
+            }}
+          >
             <div>회원 가입하기</div>
-          </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,14 +1,15 @@
-import axios from "axios";
 import { useRouter } from "next/router";
 import { BaseSyntheticEvent, useRef, useState } from "react";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 import { postUser } from "../../api/users";
-import { UserInfo } from "../../types";
 import styles from "./Signup.module.scss";
 
-axios.defaults.withCredentials = true;
+import ConfirmModal from "../../components/common/modal/ConfirmModal";
+
+import { UserInfo } from "../../types";
 
 export default function Signup() {
+  const [isWaitingModalOn, SetIsWaitingModalOn] = useState<boolean>(false);
   const [userInfo, setUserInfo] = useState<UserInfo>({
     name: "",
     email: "",
@@ -86,8 +87,10 @@ export default function Signup() {
   }
 
   function handleSignup() {
+    SetIsWaitingModalOn(true);
     postUser(userInfo, () => {
-      router.push("/");
+      SetIsWaitingModalOn(false);
+      router.push("/signin");
     });
   }
 
@@ -100,134 +103,142 @@ export default function Signup() {
   }
 
   return (
-    <div className={styles.outer}>
-      <div className={styles.container}>
-        <h1 className={styles.title}>회원가입</h1>
-        <div className={styles.form}>
-          <div className={`${styles.input} ${styles.name}`}>
-            <label htmlFor="name">이름</label>
-            <input
-              id="name"
-              name="name"
-              type="text"
-              placeholder="이름을 입력하세요"
-              ref={nameRef}
-              onChange={handleChange}
-            />
-            {isValidName ? null : (
-              <div className={styles.vm}>
-                이름은 2글자 이상 15자 이하입니다.
-              </div>
-            )}
-          </div>
-          <div className={styles.input}>
-            <label htmlFor="email">이메일</label>
-            <input
-              id="email"
-              name="email"
-              type="text"
-              placeholder="이메일을 입력하세요"
-              ref={emailRef}
-              onChange={handleChange}
-            />
-            {isValidEmail ? null : (
-              <div className={styles.vm}>올바른 이메일 형식이 아닙니다.</div>
-            )}
-          </div>
-          <div className={styles.input}>
-            <label htmlFor="password">비밀번호</label>
-            {showPassword ? (
-              <div className={styles.wrapper}>
-                <input
-                  id="password"
-                  name="password"
-                  type="text"
-                  placeholder="비밀번호를 입력하세요"
-                  ref={passwordRef}
-                  onChange={handleChange}
-                />
-                <span onClick={togglePassword} className={styles.show}>
-                  {showPassword ? <FiEyeOff /> : <FiEye />}
-                </span>
-              </div>
-            ) : (
-              <div className={styles.wrapper}>
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  placeholder="비밀번호를 입력하세요"
-                  ref={passwordRef}
-                  onChange={handleChange}
-                />
-                <span onClick={togglePassword} className={styles.show}>
-                  {showPassword ? <FiEyeOff /> : <FiEye />}
-                </span>
-              </div>
-            )}
+    <>
+      {isWaitingModalOn ? (
+        <ConfirmModal
+          title={"회원가입"}
+          content={"회원가입 중입니다. 잠시만 기다려 주십시오."}
+        />
+      ) : null}
+      <div className={styles.outer}>
+        <div className={styles.container}>
+          <h1 className={styles.title}>회원가입</h1>
+          <div className={styles.form}>
+            <div className={`${styles.input} ${styles.name}`}>
+              <label htmlFor="name">이름</label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                placeholder="이름을 입력하세요"
+                ref={nameRef}
+                onChange={handleChange}
+              />
+              {isValidName ? null : (
+                <div className={styles.vm}>
+                  이름은 2자 이상, 15자 이하여야 합니다.
+                </div>
+              )}
+            </div>
+            <div className={styles.input}>
+              <label htmlFor="email">이메일</label>
+              <input
+                id="email"
+                name="email"
+                type="text"
+                placeholder="이메일을 입력하세요"
+                ref={emailRef}
+                onChange={handleChange}
+              />
+              {isValidEmail ? null : (
+                <div className={styles.vm}>올바른 이메일 형식이 아닙니다.</div>
+              )}
+            </div>
+            <div className={styles.input}>
+              <label htmlFor="password">비밀번호</label>
+              {showPassword ? (
+                <div className={styles.wrapper}>
+                  <input
+                    id="password"
+                    name="password"
+                    type="text"
+                    placeholder="비밀번호를 입력하세요"
+                    ref={passwordRef}
+                    onChange={handleChange}
+                  />
+                  <span onClick={togglePassword} className={styles.show}>
+                    {showPassword ? <FiEyeOff /> : <FiEye />}
+                  </span>
+                </div>
+              ) : (
+                <div className={styles.wrapper}>
+                  <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    placeholder="비밀번호를 입력하세요"
+                    ref={passwordRef}
+                    onChange={handleChange}
+                  />
+                  <span onClick={togglePassword} className={styles.show}>
+                    {showPassword ? <FiEyeOff /> : <FiEye />}
+                  </span>
+                </div>
+              )}
 
-            {isValidPassword ? null : (
-              <div className={styles.vm}>
-                최소 하나 이상의 영문 대소문자와 숫자, 특수문자(@!%*#?&)를
-                포함해야 합니다.
-              </div>
-            )}
-            {isPwIncludesName ? (
-              <div className={styles.vm}>
-                이름은 비밀번호에 포함할 수 없습니다.
-              </div>
-            ) : null}
-          </div>
-          <div className={styles.input}>
-            <label htmlFor="checkPassword">비밀번호 확인</label>
-            {showPasswordCheck ? (
-              <div className={styles.wrapper}>
-                <input
-                  id="checkPassword"
-                  name="checkPassword"
-                  type="text"
-                  placeholder="비밀번호를 재입력하세요"
-                  onChange={handleChange}
-                  ref={passwordCheckRef}
-                />
-                <span onClick={togglePasswordCheck} className={styles.show}>
-                  {showPasswordCheck ? <FiEyeOff /> : <FiEye />}
-                </span>
-              </div>
+              {isValidPassword ? null : (
+                <div className={styles.vm}>
+                  최소 하나 이상의 영문 대소문자와 숫자, 특수문자(@!%*#?&)를
+                  포함해야 합니다.
+                </div>
+              )}
+              {isPwIncludesName ? (
+                <div className={styles.vm}>
+                  이름은 비밀번호에 포함할 수 없습니다.
+                </div>
+              ) : null}
+            </div>
+            <div className={styles.input}>
+              <label htmlFor="checkPassword">비밀번호 확인</label>
+              {showPasswordCheck ? (
+                <div className={styles.wrapper}>
+                  <input
+                    id="checkPassword"
+                    name="checkPassword"
+                    type="text"
+                    placeholder="비밀번호를 재입력하세요"
+                    onChange={handleChange}
+                    ref={passwordCheckRef}
+                  />
+                  <span onClick={togglePasswordCheck} className={styles.show}>
+                    {showPasswordCheck ? <FiEyeOff /> : <FiEye />}
+                  </span>
+                </div>
+              ) : (
+                <div className={styles.wrapper}>
+                  <input
+                    id="checkPassword"
+                    name="checkPassword"
+                    type="password"
+                    placeholder="비밀번호를 재입력하세요"
+                    onChange={handleChange}
+                    ref={passwordCheckRef}
+                  />
+                  <span onClick={togglePasswordCheck} className={styles.show}>
+                    {showPasswordCheck ? <FiEyeOff /> : <FiEye />}
+                  </span>
+                </div>
+              )}
+              {isValidPasswordCheck ? null : (
+                <div className={styles.vm}>비밀번호가 일치하지 않습니다.</div>
+              )}
+            </div>
+            {userInfo.name &&
+            userInfo.email &&
+            userInfo.password &&
+            isValidPasswordCheck &&
+            passwordCheckRef.current?.value.length !== 0 ? (
+              <button className={styles.btn} onClick={handleSignup}>
+                회원가입
+              </button>
             ) : (
-              <div className={styles.wrapper}>
-                <input
-                  id="checkPassword"
-                  name="checkPassword"
-                  type="password"
-                  placeholder="비밀번호를 재입력하세요"
-                  onChange={handleChange}
-                  ref={passwordCheckRef}
-                />
-                <span onClick={togglePasswordCheck} className={styles.show}>
-                  {showPasswordCheck ? <FiEyeOff /> : <FiEye />}
-                </span>
-              </div>
-            )}
-            {isValidPasswordCheck ? null : (
-              <div className={styles.vm}>비밀번호가 일치하지 않습니다.</div>
+              <button className={`${styles.btn} ${styles.invalid}`}>
+                회원가입
+              </button>
             )}
           </div>
-          {userInfo.name &&
-          userInfo.email &&
-          userInfo.password &&
-          isValidPasswordCheck &&
-          passwordCheckRef.current?.value.length !== 0 ? (
-            <button className={styles.btn} onClick={handleSignup}>
-              회원가입
-            </button>
-          ) : (
-            <button className={`${styles.btn} ${styles.invalid}`}>
-              회원가입
-            </button>
-          )}
         </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->
기존에는 로그인 시 메인 페이지로 보내는 방식으로 되어있었습니다. 하지만 로그인 직후 원래 보던 페이지로 돌아가는 게 더 적합하다고 판단해서 세션에 경로를 저장하는 방식으로 구현했습니다.


추가로 회원가입 시 비밀번호 암호화 과정으로 인해 발생한 대기시간 동안 대기 안내 모달을 띄워 사용자에게 알려주는 기능을 추가했습니다.

<img width="1200" alt="회원가입 중 모달" src="https://user-images.githubusercontent.com/84524514/184589670-98e4c5de-f616-435a-8e00-5bb1c6c24c6b.png">

