### PR TITLE
토론 목록 margin-bottom 변경

### DIFF
--- a/components/debates/debates/DebatesCards.module.scss
+++ b/components/debates/debates/DebatesCards.module.scss
@@ -6,7 +6,6 @@
     flex-direction: column;
   }
   min-width: 22rem;
-  margin-bottom: 5rem;
 }
 
 .btn_edit {
@@ -77,4 +76,5 @@
   margin-top: 4rem;
   font-size: 1.2rem;
   color: darken($c-gray-dark, 20%);
+  margin-bottom: 7rem;
 }

--- a/components/debates/debates/DebatesCards.tsx
+++ b/components/debates/debates/DebatesCards.tsx
@@ -173,9 +173,9 @@ export default function DebatesCards({
             })}
           </div>
         ))}
-        <div className={styles.empty_message}>
-          {checkEmpty() ? "해당하는 토론이 없습니다." : null}
-        </div>
+        {checkEmpty() ? (
+          <div className={styles.empty_message}>해당하는 토론이 없습니다.</div>
+        ) : null}
         <div ref={ref}></div>
       </div>
     </>


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->
토론이 없을 때 나타나는 문구의 스타일이 삼항 연산자 밖에 있어서 생긴 문제.  
토론이 없을 때 나타나는 문구의 스타일을 삼항 연산자 안으로 옮겨서 해결.

- 변경 전
   <img width="600" alt="변경 전 마진" src="https://user-images.githubusercontent.com/84524514/185164430-85ecdff0-63a0-45d8-9494-4da927626453.png">
- 변경 후
   <img width="600" alt="변경 후 마진" src="https://user-images.githubusercontent.com/84524514/185164501-f478ce90-3260-411c-90f4-724069713e31.png">


