### PR TITLE
회원가입, 로그인 및 마이페이지 개선

### DIFF
--- a/components/debates/debate/EditAndDelete.tsx
+++ b/components/debates/debate/EditAndDelete.tsx
@@ -30,7 +30,7 @@ export default function EditAndDelete({ debateId }: { debateId: number }) {
       ) : null}
       <div
         className={styles.edit}
-        onClick={() => router.push(`/edit/${debateId}`)}
+        onClick={() => router.push(`/edit?debateId=${debateId}`)}
       >
         수정
       </div>

--- a/components/debates/debate/index.tsx
+++ b/components/debates/debate/index.tsx
@@ -123,7 +123,7 @@ export default function Debate({ debateId }: { debateId: number }) {
             debate.data?.participant?.id === user.data?.id) ? (
           <div
             className={styles.participantOrEnterBtn}
-            onClick={() => router.push(`/debateroom/${debateId}`)}
+            onClick={() => router.push(`/debateroom?debateId=${debateId}`)}
           >
             입장하기
           </div>

--- a/components/debates/debateroom/Buttons.tsx
+++ b/components/debates/debateroom/Buttons.tsx
@@ -287,6 +287,6 @@ export default function Buttons({
     });
     peerRef.current?.destroy();
     socketRef.current.disconnect();
-    router.push(`/${debateId}`);
+    router.push(`/debate/debateId=${debateId}`);
   }
 }

--- a/components/debates/debateroom/index.tsx
+++ b/components/debates/debateroom/index.tsx
@@ -132,7 +132,7 @@ export default function Debateroom({
             peerRef.current?.destroy();
             socketRef.current.disconnect();
             queryClient.invalidateQueries([queryKeys.debates, `${debateId}`]);
-            router.push(`/${debateId}`);
+            router.push(`/debate?debateId=${debateId}`);
           }}
           secondBtn={"네"}
           secondFunc={() => {
@@ -148,7 +148,7 @@ export default function Debateroom({
             peerRef.current?.destroy();
             socketRef.current.disconnect();
             queryClient.invalidateQueries([queryKeys.debates, `${debateId}`]);
-            router.push(`/${debateId}`);
+            router.push(`/debate?debateId=${debateId}`);
           }}
         />
       ) : null}

--- a/components/debates/debates/DebateCard.tsx
+++ b/components/debates/debates/DebateCard.tsx
@@ -22,7 +22,7 @@ export default function DebateCard({
   return (
     <div
       className={styles.card}
-      onClick={() => router.push(`/${debate.data?.id}`)}
+      onClick={() => router.push(`/debate?debateId=${debate.data?.id}`)}
     >
       <div className={styles.category}>
         <div className={`${styles.status} ${styles.status_category}`}>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
-    "build": "next build",
+    "build": "next build && next export",
     "start": "next start -p 3001",
     "lint": "next lint"
   },

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -42,13 +42,13 @@ export default function EditPage() {
     if (!user.data) {
       setIsCheckModalOn(true);
     } else if (user.data?.id !== debate.data?.author?.id) {
-      router.push(`/${debate.data?.id}`);
+      router.push(`/debate?debateId=${debate.data?.id}`);
       toast.error("해당 토론의 작성자만 토론을 수정할 수 있습니다.");
     } else if (debate.data?.video_url) {
-      router.push(`/${debate.data?.id}`);
+      router.push(`/debate?debateId=${debate.data?.id}`);
       toast.error("이미 진행된 토론은 수정할 수 없습니다.");
     } else if (debate.data?.participant) {
-      router.push(`/${debate.data?.id}`);
+      router.push(`/debate?debateId=${debate.data?.id}`);
       toast.error("참여자가 있어 토론을 수정할 수 없습니다.");
     } else if (
       debate.data?.title === titleInput.value &&
@@ -85,7 +85,7 @@ export default function EditPage() {
         handler={handleEdit}
         createOrEdit="수정"
         routerPush={() => {
-          router.push(`/${debateId}`);
+          router.push(`/debate?debateId=${debateId}`);
         }}
       />
     </div>

--- a/pages/mypage/MyPage.module.scss
+++ b/pages/mypage/MyPage.module.scss
@@ -20,6 +20,7 @@
         justify-content: center;
         align-items: center;
         .image_wrapper {
+          margin-bottom: 2rem;
           position: relative;
           border-radius: 50%;
           border: 5px solid $c-pros;
@@ -69,15 +70,14 @@
           display: flex;
           justify-content: center;
           align-items: center;
-          transition: background-color, color, 0.2s ease-in-out;
-          &:hover {
-            background-color: $c-pros;
-            color: #fff;
-          }
           span {
             font-size: 1rem;
             font-weight: 600;
             margin-left: 5px;
+          }
+          &_cons {
+            margin-top: 0;
+            color: $c-cons;
           }
         }
       }

--- a/pages/mypage/MyPage.module.scss
+++ b/pages/mypage/MyPage.module.scss
@@ -5,8 +5,10 @@
   justify-content: center;
   align-items: center;
   padding: 100px;
+  min-width: 22rem;
   .inner {
     width: 768px;
+    min-width: 22rem;
     text-align: center;
     .wrapper {
       display: flex;
@@ -89,6 +91,7 @@
             margin-bottom: 20px;
             position: relative;
             .validation {
+              margin-top: 1rem;
               position: absolute;
               top: -3rem;
               font-size: 0.8rem;
@@ -122,7 +125,7 @@
               font-size: 1.1rem;
             }
             .input::placeholder {
-              color: $c-pros;
+              color: darken($c-gray_dark, 20%);
             }
             .save {
               border: none;

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -15,7 +15,6 @@ import Error from "../../components/common/Error";
 import ChangePasswordModal from "../../components/common/modal/ChangePasswordModal";
 import SignOutModal from "../../components/common/modal/SignOutModal";
 
-// Todo: createObjectURL 에러 해결, 페이지 접근 권한 설정, 프로필 변경 취소 버튼 제작
 export default function MyPagePage() {
   const router = useRouter();
   const [image, setImage] = useState<File>();
@@ -84,6 +83,11 @@ export default function MyPagePage() {
     router.push("/signin");
   };
 
+  const handleCancel = () => {
+    setFormData(undefined);
+    setPreviewImageUrl("");
+  };
+
   const stopEvent = (e: BaseSyntheticEvent) => {
     e.preventDefault();
   };
@@ -147,11 +151,20 @@ export default function MyPagePage() {
                   </div>
                 )}
               </div>
-              {user.data ? (
-                <button className={styles.save_btn} onClick={handleImageSave}>
-                  <FiCheckSquare />
-                  <span>저장</span>
-                </button>
+              {user.data && formData && previewImageUrl ? (
+                <>
+                  <button className={styles.save_btn} onClick={handleImageSave}>
+                    <FiCheckSquare />
+                    <span>저장</span>
+                  </button>
+                  <button
+                    className={`${styles.save_btn} ${styles.save_btn_cons}`}
+                    onClick={handleCancel}
+                  >
+                    <FiXSquare />
+                    <span>취소</span>
+                  </button>
+                </>
               ) : null}
             </div>
             {user.data ? (

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,20 +1,23 @@
 import Image from "next/image";
 import { BaseSyntheticEvent, useEffect, useState } from "react";
 import { FiEdit, FiCheckSquare, FiXSquare } from "react-icons/fi";
+import { useRouter } from "next/router";
 
 import {
   useGetUser,
   usePatchUserImage,
   usePatchUserNickname,
 } from "../../utils/queries/users";
+import { removeSpace } from "../../utils/common/removeSpace";
 import styles from "./MyPage.module.scss";
 
 import Error from "../../components/common/Error";
 import ChangePasswordModal from "../../components/common/modal/ChangePasswordModal";
 import SignOutModal from "../../components/common/modal/SignOutModal";
 
-// Todo: 이름 유효성 검사(회원가입에서도 필요), createObjectURL 에러 해결, 페이지 접근 권한 설정, 프로필 변경 취소 버튼 제작 / 이름 변경 시 사진 밀리는거 해결, 인풋에 기존 아이디 유지 및 placeholder 색 구분
+// Todo: createObjectURL 에러 해결, 페이지 접근 권한 설정, 프로필 변경 취소 버튼 제작
 export default function MyPagePage() {
+  const router = useRouter();
   const [image, setImage] = useState<File>();
   const [previewImageUrl, setPreviewImageUrl] = useState<string>("");
   const [formData, setFormData] = useState<FormData>();
@@ -42,14 +45,16 @@ export default function MyPagePage() {
   };
 
   const handleChangeNickname = (e: BaseSyntheticEvent) => {
+    const nickname = removeSpace(e.target.value);
     if (
-      (e.target.value.length >= 1 && e.target.value.length < 2) ||
-      e.target.value.length >= 16
+      (nickname.length >= 1 && nickname.length < 2) ||
+      nickname.length >= 16 ||
+      /[^\s\w가-힣]/.test(nickname)
     ) {
       setIsValidationShow(true);
     } else {
       setIsValidationShow(false);
-      setNickname(e.target.value);
+      setNickname(nickname);
     }
   };
 
@@ -75,6 +80,10 @@ export default function MyPagePage() {
     setIsEdit(false);
   };
 
+  const handlePushSignIn = () => {
+    router.push("/signin");
+  };
+
   const stopEvent = (e: BaseSyntheticEvent) => {
     e.preventDefault();
   };
@@ -98,102 +107,117 @@ export default function MyPagePage() {
           <div className={styles.wrapper}>
             <div className={styles.profile_container}>
               <div className={styles.image_wrapper}>
+                <Image
+                  className={styles.image}
+                  alt="profile_image"
+                  src={
+                    !user.data
+                      ? "/images/profiles/default-gray.png"
+                      : previewImageUrl
+                      ? previewImageUrl
+                      : user.data?.profile_image !== "temp default image"
+                      ? `${process.env.NEXT_PUBLIC_API_URL}/uploads/${user.data?.profile_image}`
+                      : "/images/profiles/default-green.png"
+                  }
+                  width="300"
+                  height="300"
+                  unoptimized={true}
+                />
                 {user.data ? (
-                  <Image
-                    className={styles.image}
-                    alt="profile_image"
-                    src={
-                      previewImageUrl
-                        ? previewImageUrl
-                        : user.data?.profile_image !== "temp default image"
-                        ? `${process.env.NEXT_PUBLIC_API_URL}/uploads/${user.data?.profile_image}`
-                        : "/images/profiles/default-green.png"
-                    }
-                    width="300"
-                    height="300"
-                    unoptimized={true}
-                  />
-                ) : null}
-                <form
-                  encType="multipart/form-data"
-                  onSubmit={stopEvent}
-                  className={styles.form}
-                >
-                  <label htmlFor="input-file" className={styles.file_btn}>
-                    <FiEdit />
-                    <span>수정</span>
-                  </label>
-                  <input
-                    type="file"
-                    id="input-file"
-                    onChange={handleChangeImage}
-                  />
-                </form>
-              </div>
-              <button className={styles.save_btn} onClick={handleImageSave}>
-                <FiCheckSquare />
-                <span>저장</span>
-              </button>
-            </div>
-            <div className={styles.info_container}>
-              <div className={styles.name_wrapper}>
-                {isEdit ? (
-                  <div className={styles.name}>
-                    {isValidationShow ? (
-                      <div className={styles.validation}>
-                        이름은 2자 이상 15자 이하로 만들어 주세요.
-                      </div>
-                    ) : null}
-                    <input
-                      className={styles.input}
-                      placeholder={user.data?.nickname}
-                      onChange={handleChangeNickname}
-                    />
-                    {isValidationShow ? null : (
-                      <button
-                        onClick={handleNicknameSave}
-                        className={styles.save}
-                      >
-                        <FiCheckSquare />
-                      </button>
-                    )}
-                    <button
-                      onClick={handleNicknameEditCancel}
-                      className={styles.cancel}
-                    >
-                      <FiXSquare />
-                    </button>
-                  </div>
-                ) : user.data ? (
-                  <div className={styles.name}>
-                    <div className={styles.nickname}>{user.data.nickname}</div>
-                    <button
-                      onClick={handleNicknameEdit}
-                      className={styles.edit}
-                    >
+                  <form
+                    encType="multipart/form-data"
+                    onSubmit={stopEvent}
+                    className={styles.form}
+                  >
+                    <label htmlFor="input-file" className={styles.file_btn}>
                       <FiEdit />
-                    </button>
+                      <span>수정</span>
+                    </label>
+                    <input
+                      type="file"
+                      id="input-file"
+                      onChange={handleChangeImage}
+                    />
+                  </form>
+                ) : (
+                  <div className={styles.form}>
+                    <div className={styles.file_btn} onClick={handlePushSignIn}>
+                      로그인
+                    </div>
                   </div>
-                ) : null}
+                )}
               </div>
               {user.data ? (
-                <div className={styles.email}>{user.data.email}</div>
+                <button className={styles.save_btn} onClick={handleImageSave}>
+                  <FiCheckSquare />
+                  <span>저장</span>
+                </button>
               ) : null}
-              <div
-                className={styles.password}
-                onClick={() => setIsPasswordModalOn(true)}
-              >
-                비밀번호 변경
-              </div>
-              <div
-                className={styles.unsubscribe}
-                onClick={() => {
-                  setIsSignOutModalOpen(true);
-                }}
-              >
-                로그아웃
-              </div>
             </div>
+            {user.data ? (
+              <div className={styles.info_container}>
+                <div className={styles.name_wrapper}>
+                  {isEdit ? (
+                    <div className={styles.name}>
+                      {isValidationShow ? (
+                        <div className={styles.validation}>
+                          이름은 낱자를 제외한 한글, 영어, 숫자만 포함 가능하며
+                          2자 이상, 15자 이하여야 합니다.
+                        </div>
+                      ) : null}
+                      <input
+                        className={styles.input}
+                        placeholder={user.data?.nickname}
+                        onChange={handleChangeNickname}
+                      />
+                      {isValidationShow ? null : (
+                        <button
+                          onClick={handleNicknameSave}
+                          className={styles.save}
+                        >
+                          <FiCheckSquare />
+                        </button>
+                      )}
+                      <button
+                        onClick={handleNicknameEditCancel}
+                        className={styles.cancel}
+                      >
+                        <FiXSquare />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className={styles.name}>
+                      <div className={styles.nickname}>
+                        {user.data.nickname}
+                      </div>
+                      <button
+                        onClick={handleNicknameEdit}
+                        className={styles.edit}
+                      >
+                        <FiEdit />
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div className={styles.email}>{user.data.email}</div>
+
+                <div
+                  className={styles.password}
+                  onClick={() => setIsPasswordModalOn(true)}
+                >
+                  비밀번호 변경
+                </div>
+                <div
+                  className={styles.unsubscribe}
+                  onClick={() => {
+                    setIsSignOutModalOpen(true);
+                  }}
+                >
+                  로그아웃
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -38,9 +38,9 @@ export default function MyPagePage() {
   }, [image]);
 
   const handleChangeImage = (e: BaseSyntheticEvent) => {
+    if (!e.target.files[0]) return;
     setImage(e.target.files[0]);
-    const srcUrl = window.URL.createObjectURL(e.target.files[0]);
-    setPreviewImageUrl(srcUrl);
+    setPreviewImageUrl(window.URL.createObjectURL(e.target.files[0]));
   };
 
   const handleChangeNickname = (e: BaseSyntheticEvent) => {
@@ -61,6 +61,8 @@ export default function MyPagePage() {
     if (user.data) {
       patchUserImage.mutate();
       setIsValidationShow(false);
+      handleCancel();
+      window.URL.revokeObjectURL(previewImageUrl);
     }
   };
 

--- a/pages/signin/Signin.module.scss
+++ b/pages/signin/Signin.module.scss
@@ -25,14 +25,13 @@
   width: 100%;
   height: 100%;
   display: flex;
+  padding: 3rem;
   justify-content: center;
-  align-items: center;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  align-items: flex-start;
   z-index: -1;
+  min-width: 22rem;
   .container {
+    margin-top: 2rem;
     background-color: #fff;
     padding: 2rem;
     border: 1px solid #ececec;

--- a/pages/signup/Signup.module.scss
+++ b/pages/signup/Signup.module.scss
@@ -5,14 +5,13 @@
   height: 100%;
   display: flex;
   justify-content: center;
-  align-items: center;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  align-items: flex-start;
+  padding: 1rem;
   z-index: -1;
+  min-width: 22rem;
 }
 .container {
+  margin: 2rem;
   display: flex;
   flex-direction: column;
   background-color: #fff;

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import { BaseSyntheticEvent, useRef, useState } from "react";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 import { postUser } from "../../api/users";
+import { removeSpace } from "../../utils/common/removeSpace";
 import styles from "./Signup.module.scss";
 
 import ConfirmModal from "../../components/common/modal/ConfirmModal";
@@ -39,10 +40,16 @@ export default function SignupPage() {
   function handleChange(e: BaseSyntheticEvent) {
     const value = e.target.value;
     const valueType = e.target.name;
+
     if (valueType === "name") {
-      if (value.length >= 2 && value.length <= 15) {
+      const nickname = removeSpace(value);
+      if (
+        nickname.length >= 2 &&
+        nickname.length <= 15 &&
+        !/[^\s\w가-힣]/.test(nickname)
+      ) {
         setIsValidName(true);
-        setUserInfo({ ...userInfo, [valueType]: value });
+        setUserInfo({ ...userInfo, [valueType]: nickname });
       } else {
         setIsValidName(false);
         setUserInfo({ ...userInfo, [valueType]: "" });
@@ -126,7 +133,8 @@ export default function SignupPage() {
               />
               {isValidName ? null : (
                 <div className={styles.vm}>
-                  이름은 2자 이상, 15자 이하여야 합니다.
+                  이름은 낱자를 제외한 한글, 영어, 숫자만 포함 가능하며 2자
+                  이상, 15자 이하여야 합니다.
                 </div>
               )}
             </div>
@@ -178,8 +186,9 @@ export default function SignupPage() {
 
               {isValidPassword ? null : (
                 <div className={styles.vm}>
-                  최소 하나 이상의 영문 대소문자와 숫자, 특수문자(@!%*#?&)를
-                  포함해야 합니다.
+                  {
+                    "최소 하나 이상의 영문 대소문자와 숫자, 특수문자(@!%*#?&)를 포함해야 합니다."
+                  }
                 </div>
               )}
               {isPwIncludesName ? (

--- a/utils/debates/debateroom/webSocket.ts
+++ b/utils/debates/debateroom/webSocket.ts
@@ -99,7 +99,7 @@ export const useWebSocket = ({
           });
           peerRef.current?.destroy();
           socketRef.current.disconnect();
-          router.push(`/${debateId}`);
+          router.push(`/debate?debateId=${debateId}`);
         });
 
         socketRef.current.on("peerJoin", () => {

--- a/utils/queries/debates.ts
+++ b/utils/queries/debates.ts
@@ -117,7 +117,7 @@ export const usePatchDebate = (
     onSuccess: () => {
       queryClient.invalidateQueries([queryKeys.debates], { exact: true });
       if (/\/edit/.test(router.pathname)) {
-        router.push(`/${debateId}`);
+        router.push(`/debate?debateId=${debateId}`);
       }
     },
     onError: (


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->
### 회원가입 및 로그인 페이지 짤림 문제

회원가입 페이지와 로그인 페이지에서 창의 세로 길이가 줄어들었을 경우 잘림 현상과 함께 드래그도 할 수 없는 문제를 발견했다. 원인은 `outer`를 화면에 고정된 요소로 만들어 뒀기 때문이었다. 그래서 해당 부분을 제거해서 잘림 현상을 해결했다.

그리고 align-items를 flex-start로 만들어 위로 튀어나옴 문제를 해결했다. 또한 `outer`에 padding을 주고 내부의 `container`에는 margin을 줘서 경계에 너무 붙지 않게 만들었다.

- 변경 전 (회원가입)
  <img width="700" alt="회원가입 페이지 짤림" src="https://user-images.githubusercontent.com/84524514/186260562-d3ae9e1e-cc8e-4d8f-bc38-d5d51199a1f2.png">

- 변경 후 (회원가입)
  <img width="600" alt="회원가입 페이지 해결" src="https://user-images.githubusercontent.com/84524514/186261989-818e2329-b3ec-42c8-bfbe-c506c8a4698d.png">

- 기존 스타일 (회원가입)
  ```scss
  .outer {
    width: 100%;
    height: 100%;
    display: flex;
    justify-content: center;
    align-items: center;
    position: fixed;
    top: 50%;
    left: 50%;
    transform: translate(-50%, -50%);
    z-index: -1;
  }
  ```
- 변경 후 스타일 (회원가입)
  ```scss
  .outer {
    width: 100%;
    height: 100%;
    display: flex;
    justify-content: center;
    align-items: flex-start;
    padding: 1rem;
    z-index: -1;
    min-width: 22rem;
  }
  .container {
    margin: 2rem;
  }
  ```

### 비로그인 시 마이페이지 렌더링

기존 마이페이지는 사용자 정보가 없을 때 제대로 처리하지 못하는 문제가 있었다. 처음에는 사용자 정보가 없을 때 에러 페이지를 렌더링 했으나 페이지 이동 혹은 로그아웃 시 깜박이듯 에러 화면이 노출되는 것이 마음에 들지 않았다. 그래서 사용자 정보가 없을 때 기본 이미지와 함께 로그인 버튼을 보여 주는 것으로 변경했다.

- 기존 마이페이지 (비로그인 시)
  <img width="800" alt="스크린샷 2022-08-24 오전 6 41 46" src="https://user-images.githubusercontent.com/84524514/186291142-e5607de2-28f3-4302-9609-328eb4262cd4.png">
- 개선 마이페이지 (비로그인 시)
  <img width="700" alt="스크린샷 2022-08-24 오전 7 08 50" src="https://user-images.githubusercontent.com/84524514/186291169-21549078-dedf-4d90-bdef-3c12fec5aace.png">

### createObjectURL 에러 해결

<img width="1200" alt="프로필 이미지 변경 문제" src="https://user-images.githubusercontent.com/84524514/185069278-5bf399fa-bc74-43f4-ba8e-0c9494ff48ff.png">

사용자 프로필 이미지 수정 후 저장하지 않고 파일 업로드 도달에서 취소를 누르면 에러가 발생했다. 적절한 타입이 아닌 데이터가 들어갈 경우 나는 에러로 `handleChangeImage`에 조건을 걸어서 걸러주는 것으로 해결했다. 추가로 `revokeObjectURL`를 사용해 메모리 누수를 막았다.

```ts
const handleChangeImage = (e: BaseSyntheticEvent) => {
  if (!e.target.files[0]) return;
  setImage(e.target.files[0]);
  setPreviewImageUrl(window.URL.createObjectURL(e.target.files[0]));
};
```

```ts
const handleImageSave = () => {
  if (user.data) {
    ...
    window.URL.revokeObjectURL(previewImageUrl);
  }
};
```

Ps. 추가로 이미지를 변경한 이후 다시 취소할 수 있게 버튼을 만들었다.
<img width="700" alt="스크린샷 2022-08-24 오전 7 56 45" src="https://user-images.githubusercontent.com/84524514/186291212-bb1c8ab9-66aa-4f69-bda7-155e9ff7dc80.png">

### 기타 문제 해결

- 회원가입, 로그인 및 마이페이지 최소 넓이 설정
- 마이페이지 placeholder 색상 회색으로 변경 (구분 용의)
- 회원가입 및 마이페이지 이름 유효성 검사 개선 (낱자를 뺀 한글, 영어, 숫자)

