### PR TITLE
토론 진행 버튼 수정

### DIFF
--- a/components/debates/debateroom/Buttons.module.scss
+++ b/components/debates/debateroom/Buttons.module.scss
@@ -58,6 +58,7 @@
 
 .name {
   color: darken($c-gray_dark, 30%);
+  @include disabledText;
 }
 
 @include mobile {

--- a/components/debates/debateroom/Buttons.tsx
+++ b/components/debates/debateroom/Buttons.tsx
@@ -111,43 +111,63 @@ export default function Buttons({
             <div className={styles.name}>음소거 해제</div>
           </div>
         ) : (
-          <div
-            onClick={() =>
-              toggleMic({ streamRef, isMicOn: !isMicOn, setIsMicOn })
-            }
-          >
+          <>
             {isMicOn ? (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_pros}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_pros}`}
+                  onClick={() =>
+                    toggleMic({ streamRef, isMicOn: !isMicOn, setIsMicOn })
+                  }
+                >
                   <IoMic />
                 </div>
                 <div className={styles.name}>음소거</div>
               </div>
             ) : (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_cons}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_cons}`}
+                  onClick={() =>
+                    toggleMic({ streamRef, isMicOn: !isMicOn, setIsMicOn })
+                  }
+                >
                   <IoMicOff />
                 </div>
                 <div className={styles.name}>음소거 해제</div>
               </div>
             )}
-          </div>
+          </>
         )}
-        <div
-          onClick={() =>
-            toggleVideo({ streamRef, isVideoOn: !isVideoOn, setIsVideoOn })
-          }
-        >
+        <div>
           {isVideoOn ? (
             <div className={styles.box}>
-              <div className={`${styles.btn} ${styles.btn_pros}`}>
+              <div
+                className={`${styles.btn} ${styles.btn_pros}`}
+                onClick={() =>
+                  toggleVideo({
+                    streamRef,
+                    isVideoOn: !isVideoOn,
+                    setIsVideoOn,
+                  })
+                }
+              >
                 <IoVideocam />
               </div>
               <div className={styles.name}>비디오 중지</div>
             </div>
           ) : (
             <div className={styles.box}>
-              <div className={`${styles.btn} ${styles.btn_cons}`}>
+              <div
+                className={`${styles.btn} ${styles.btn_cons}`}
+                onClick={() =>
+                  toggleVideo({
+                    streamRef,
+                    isVideoOn: !isVideoOn,
+                    setIsVideoOn,
+                  })
+                }
+              >
                 <IoVideocamOff />
               </div>
               <div className={styles.name}>비디오 시작</div>
@@ -215,27 +235,33 @@ export default function Buttons({
             <div className={styles.name}>넘기기</div>
           </div>
         ) : peerStream ? (
-          <div
-            onClick={() => {
-              toggleReady({ isReady: !isReady, setIsReady });
-            }}
-          >
+          <>
             {isReady ? (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_black}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_black}`}
+                  onClick={() => {
+                    toggleReady({ isReady: !isReady, setIsReady });
+                  }}
+                >
                   <MdStop />
                 </div>
                 <div className={styles.name}>준비 취소</div>
               </div>
             ) : (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_black}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_black}`}
+                  onClick={() => {
+                    toggleReady({ isReady: !isReady, setIsReady });
+                  }}
+                >
                   <IoPlay />
                 </div>
                 <div className={styles.name}>준비</div>
               </div>
             )}
-          </div>
+          </>
         ) : (
           <div className={styles.box}>
             <div className={`${styles.btn} ${styles.btn_disabled}`}>
@@ -245,8 +271,11 @@ export default function Buttons({
           </div>
         )}
         {isStart ? null : (
-          <div className={styles.box} onClick={() => setIsExitModalOn(true)}>
-            <div className={`${styles.btn} ${styles.btn_black}`}>
+          <div className={styles.box}>
+            <div
+              className={`${styles.btn} ${styles.btn_black}`}
+              onClick={() => setIsExitModalOn(true)}
+            >
               <TbArrowBarRight />
             </div>
             <div className={styles.name}>나가기</div>

--- a/components/debates/debateroom/experience/Button.tsx
+++ b/components/debates/debateroom/experience/Button.tsx
@@ -126,49 +126,69 @@ export default function Buttons({
             <div className={styles.name}>음소거 해제</div>
           </div>
         ) : (
-          <div
-            onClick={() =>
-              toggleMic({ streamRef, isMicOn: !isMicOn, setIsMicOn })
-            }
-          >
+          <>
             {isMicOn ? (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_pros}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_pros}`}
+                  onClick={() =>
+                    toggleMic({ streamRef, isMicOn: !isMicOn, setIsMicOn })
+                  }
+                >
                   <IoMic />
                 </div>
                 <div className={styles.name}>음소거</div>
               </div>
             ) : (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_cons}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_cons}`}
+                  onClick={() =>
+                    toggleMic({ streamRef, isMicOn: !isMicOn, setIsMicOn })
+                  }
+                >
                   <IoMicOff />
                 </div>
                 <div className={styles.name}>음소거 해제</div>
               </div>
             )}
-          </div>
+          </>
         )}
-        <div
-          onClick={() =>
-            toggleVideo({ streamRef, isVideoOn: !isVideoOn, setIsVideoOn })
-          }
-        >
+        <>
           {isVideoOn ? (
             <div className={styles.box}>
-              <div className={`${styles.btn} ${styles.btn_pros}`}>
+              <div
+                className={`${styles.btn} ${styles.btn_pros}`}
+                onClick={() =>
+                  toggleVideo({
+                    streamRef,
+                    isVideoOn: !isVideoOn,
+                    setIsVideoOn,
+                  })
+                }
+              >
                 <IoVideocam />
               </div>
               <div className={styles.name}>비디오 중지</div>
             </div>
           ) : (
             <div className={styles.box}>
-              <div className={`${styles.btn} ${styles.btn_cons}`}>
+              <div
+                className={`${styles.btn} ${styles.btn_cons}`}
+                onClick={() =>
+                  toggleVideo({
+                    streamRef,
+                    isVideoOn: !isVideoOn,
+                    setIsVideoOn,
+                  })
+                }
+              >
                 <IoVideocamOff />
               </div>
               <div className={styles.name}>비디오 시작</div>
             </div>
           )}
-        </div>
+        </>
         {checkScreenShareDisable() ? (
           <div className={styles.box}>
             <div className={`${styles.btn} ${styles.btn_disabled}`}>
@@ -230,31 +250,41 @@ export default function Buttons({
             <div className={styles.name}>넘기기</div>
           </div>
         ) : (
-          <div
-            onClick={() => {
-              toggleReady({ isReady: !isReady, setIsReady });
-              handleReady();
-            }}
-          >
+          <>
             {isReady ? (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_black}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_black}`}
+                  onClick={() => {
+                    toggleReady({ isReady: !isReady, setIsReady });
+                    handleReady();
+                  }}
+                >
                   <MdStop />
                 </div>
                 <div className={styles.name}>준비 취소</div>
               </div>
             ) : (
               <div className={styles.box}>
-                <div className={`${styles.btn} ${styles.btn_black}`}>
+                <div
+                  className={`${styles.btn} ${styles.btn_black}`}
+                  onClick={() => {
+                    toggleReady({ isReady: !isReady, setIsReady });
+                    handleReady();
+                  }}
+                >
                   <IoPlay />
                 </div>
                 <div className={styles.name}>준비</div>
               </div>
             )}
-          </div>
+          </>
         )}
-        <div className={styles.box} onClick={() => setIsExitModalOn(true)}>
-          <div className={`${styles.btn} ${styles.btn_black}`}>
+        <div className={styles.box}>
+          <div
+            className={`${styles.btn} ${styles.btn_black}`}
+            onClick={() => setIsExitModalOn(true)}
+          >
             <TbArrowBarRight />
           </div>
           <div className={styles.name}>나가기</div>


### PR DESCRIPTION
<!-- 제목의 경우 [Type] 사용하지 않기 -->
<!-- 변경 사항을 개조식으로 작성 -->
<!-- 변경 사항이 여러 개일 경우 "-"로 구분 -->
<!-- "어떻게" 보다는 "무엇을", "왜"를 설명 -->
<!-- 결과물에 대한 Screenshot 및 Gif 추가 가능 -->
<!-- Reviewers 등록 -->
<!-- Assignees 등록 -->
<!-- 포함되는 Commit의 Label 등록 -->
<img width="450" alt="버튼" src="https://user-images.githubusercontent.com/84524514/189609115-44f050a6-8389-40b2-9287-5b0260c73b2f.png">

버튼의 이름을 눌러도 이벤트가 발생했고, 버튼의 이름이 드래그가 가능했다. 그래서 버튼의 이름을 눌렀을 때는 이벤트가 발생하지 않게 만들고 드래그도 불가능하게 만들었다.